### PR TITLE
fix: keep lighting module base bundle-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - (placeholder)
 
 - **Fixed**
-  - (placeholder)
+  - Prevent browser bundlers from rewriting the lighting module base URL into a
+    `data:` asset URL before technique WGSL URLs are constructed.
 
 - **Security**
   - (placeholder)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const baseUrl = (() => {
   if (typeof __IMPORT_META_URL__ !== "undefined") {
-    return new URL("./index.js", __IMPORT_META_URL__);
+    return new URL(__IMPORT_META_URL__);
   }
   if (typeof __filename !== "undefined" && typeof require !== "undefined") {
     const { pathToFileURL } = require("node:url");

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -76,6 +76,31 @@ test("default lighting technique prelude URL points at hybrid prelude", () => {
   );
 });
 
+test("module base does not use a browser-bundler asset URL pattern", () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, "..", "src", "index.js"),
+    "utf8"
+  );
+
+  assert.doesNotMatch(
+    source,
+    /new URL\(\s*["'`]\.\/index\.js["'`]\s*,\s*__IMPORT_META_URL__\s*\)/,
+    "browser bundlers rewrite static new URL('./index.js', import.meta.url) expressions into asset URLs"
+  );
+});
+
+test("browser-like module metadata resolves technique URLs from the package", async () => {
+  const module = await importLightingModuleWithBase(
+    "https://lighting.example/pkg/dist/index.js",
+    "browser-module-url"
+  );
+
+  assert.equal(
+    module.lightingPreludeWgslUrl.href,
+    "https://lighting.example/pkg/dist/techniques/hybrid/prelude.wgsl"
+  );
+});
+
 test("lighting job WGSL defines process_job entry points", () => {
   for (const techniqueName of lightingTechniqueNames) {
     const technique = lightingTechniques[techniqueName];


### PR DESCRIPTION
## Summary
- Avoid the static `new URL("./index.js", import.meta.url)` module-base pattern that Vite/Rolldown rewrites into a data asset URL.
- Add regression coverage for the bundler-sensitive pattern and browser-like module metadata.
- Document the production GPU demo fix in the unreleased changelog.

## Validation
- `node@24 node_modules/eslint/bin/eslint.js . --max-warnings=0`
- `node@24 --check src/index.js && node@24 --check demo/lighting-demo-config.js && node@24 --check demo/main.js`
- `node@24 node_modules/c8/bin/c8.js --reporter=lcov --reporter=text node@24 --test`
- `node@24 node_modules/tsup/dist/cli-default.js`
- `npm run audit:npm`
- `node@24 scripts/verify-public-package.cjs`

Fixes Plasius-LTD/gpu-lighting#9.
