### PR TITLE
fix: avoid direct import meta URL construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - (placeholder)
 
 - **Fixed**
-  - (placeholder)
+  - Keep import metadata out of direct URL constructor calls so browser
+    bundlers do not rewrite the lighting module base into a `data:` asset URL.
 
 - **Security**
   - (placeholder)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,10 @@
+function createModuleBaseUrl(metaUrl) {
+  return new URL(String(metaUrl));
+}
+
 const baseUrl = (() => {
   if (typeof __IMPORT_META_URL__ !== "undefined") {
-    return new URL(__IMPORT_META_URL__);
+    return createModuleBaseUrl(__IMPORT_META_URL__);
   }
   if (typeof __filename !== "undefined" && typeof require !== "undefined") {
     const { pathToFileURL } = require("node:url");

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -84,8 +84,8 @@ test("module base does not use a browser-bundler asset URL pattern", () => {
 
   assert.doesNotMatch(
     source,
-    /new URL\(\s*["'`]\.\/index\.js["'`]\s*,\s*__IMPORT_META_URL__\s*\)/,
-    "browser bundlers rewrite static new URL('./index.js', import.meta.url) expressions into asset URLs"
+    /new URL\(\s*(?:["'`]\.\/index\.js["'`]\s*,\s*)?__IMPORT_META_URL__\s*\)/,
+    "browser bundlers rewrite direct new URL(import.meta.url) patterns into asset URLs"
   );
 });
 


### PR DESCRIPTION
## Summary
- Keep import metadata out of direct `new URL(...)` constructor arguments so Vite/Rolldown cannot rewrite it into a `data:` asset URL.
- Tighten the regression test to block both static index URL and direct import-meta URL constructor patterns.
- Document the follow-up production bundle fix in the unreleased changelog.

## Validation
- `node@24 node_modules/eslint/bin/eslint.js . --max-warnings=0`
- `node@24 --check src/index.js && node@24 --check demo/lighting-demo-config.js && node@24 --check demo/main.js`
- `node@24 node_modules/c8/bin/c8.js --reporter=lcov --reporter=text node@24 --test`
- `node@24 node_modules/tsup/dist/cli-default.js`
- `npm run audit:npm`
- `node@24 scripts/verify-public-package.cjs`

Refs Plasius-LTD/gpu-lighting#9.
