### PR TITLE
fix: construct module URLs opaquely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - (placeholder)
 
 - **Fixed**
-  - (placeholder)
+  - Use an opaque URL constructor path for import metadata so Vite/Rolldown
+    cannot inline the lighting module URL as a generated `data:` asset.
 
 - **Security**
   - (placeholder)

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 function createModuleBaseUrl(metaUrl) {
-  return new URL(String(metaUrl));
+  return Reflect.construct(URL, [String(metaUrl)]);
 }
 
 const baseUrl = (() => {

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -84,8 +84,13 @@ test("module base does not use a browser-bundler asset URL pattern", () => {
 
   assert.doesNotMatch(
     source,
-    /new URL\(\s*(?:["'`]\.\/index\.js["'`]\s*,\s*)?__IMPORT_META_URL__\s*\)/,
+    /new URL\(\s*(?:String\(\s*)?(?:["'`]\.\/index\.js["'`]\s*,\s*)?__IMPORT_META_URL__/,
     "browser bundlers rewrite direct new URL(import.meta.url) patterns into asset URLs"
+  );
+  assert.match(
+    source,
+    /Reflect\.construct\(\s*URL,\s*\[\s*String\(metaUrl\)\s*\]\s*\)/,
+    "import metadata must be converted through an opaque constructor call"
   );
 });
 


### PR DESCRIPTION
## Summary
- Construct the module URL through `Reflect.construct(URL, ...)` so Vite/Rolldown cannot rewrite import metadata into generated data assets.
- Tighten regression coverage to require the opaque constructor path.
- Document the production bundle fix in the unreleased changelog.

## Validation
- `node@24 node_modules/eslint/bin/eslint.js . --max-warnings=0`
- `node@24 --check src/index.js && node@24 --check demo/lighting-demo-config.js && node@24 --check demo/main.js`
- `node@24 node_modules/c8/bin/c8.js --reporter=lcov --reporter=text node@24 --test`
- `node@24 node_modules/tsup/dist/cli-default.js`
- `npm run audit:npm`
- `node@24 scripts/verify-public-package.cjs`
- Local consuming site bundle check after copying the rebuilt dist into `plasius-ltd-site` node_modules.

Refs Plasius-LTD/gpu-lighting#9.
