### PR TITLE
feat: replace placeholder lighting kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,19 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added `createLightingProfileModeLadder()` plus default reference-first
+    policy metadata so downstream runtimes can expose `reference`, `hybrid`,
+    and `realtime` as governor-managed lighting modes with a `30` FPS, `4`
+    frame adaptive window.
+  - Replaced the placeholder `pathtracer` WGSL jobs with concrete path trace,
+    accumulation, and denoise kernels plus a concrete hybrid
+    `reflectionResolve` WGSL stage.
 
 - **Changed**
-  - (placeholder)
+  - Documented that the new reference-first ladder is a performance-planning
+    contract for real renderers, and that the shipped WGSL kernels still
+    require downstream renderer integration before they become a live RT frame
+    path.
 
 - **Fixed**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Lighting worker manifests now publish `schedulerMode: "dag"` plus per-job
 
 ```js
 import {
+  createLightingProfileModeLadder,
   getLightingProfile,
   loadLightingProfile,
 } from "@plasius/gpu-lighting";
@@ -130,7 +131,56 @@ const profile = getLightingProfile("realtime");
 
 const plan = await loadLightingProfile("realtime");
 // plan.techniques is an array of loaded prelude+job WGSL bundles.
+
+const modeLadder = createLightingProfileModeLadder();
+// modeLadder exposes reference -> hybrid -> realtime ordering for gpu-performance.
 ```
+
+## Usage (reference-first performance ladder)
+
+```js
+import {
+  createGpuPerformanceGovernor,
+  createQualityLadderAdapter,
+} from "@plasius/gpu-performance";
+import {
+  createLightingProfileModeLadder,
+} from "@plasius/gpu-lighting";
+
+const lightingModePlan = createLightingProfileModeLadder({
+  initialProfile: "reference",
+});
+const lightingMode = createQualityLadderAdapter(lightingModePlan);
+
+const governor = createGpuPerformanceGovernor({
+  device,
+  modules: [lightingMode],
+  target: lightingModePlan.target,
+  adaptation: lightingModePlan.adaptation,
+});
+```
+
+`createLightingProfileModeLadder()` publishes the policy contract for the
+reference-first mode you described:
+
+- start from `reference`
+- keep a 4-frame adaptation window
+- hold the premium mode while the negotiated average remains at or above `30`
+  FPS
+- degrade the whole lighting profile to `hybrid`, then `realtime`, only when
+  that window can no longer sustain the budget
+
+The package now ships concrete WGSL contracts for:
+
+- `pathtracer.pathTrace`: analytic scene tracing, bounce integration, and sky fallback
+- `pathtracer.accumulate`: progressive history resolve with reset handling
+- `pathtracer.denoise`: spatial-temporal bilateral filtering for reference previews
+- `hybrid.reflectionResolve`: surface-aware reflection shading with roughness/fresnel shaping
+
+This is still a catalog/planning package rather than proof of a finished
+end-to-end renderer. Downstream runtimes such as `@plasius/gpu-renderer` still
+need to bind real scene buffers and execute these kernels on the live frame
+graph.
 
 ## Profiles
 

--- a/docs/adrs/adr-0007: Reference-First Adaptive Lighting Profile Ladder.md
+++ b/docs/adrs/adr-0007: Reference-First Adaptive Lighting Profile Ladder.md
@@ -1,0 +1,65 @@
+# ADR-0007: Reference-First Adaptive Lighting Profile Ladder
+
+## Status
+
+Accepted
+
+## Context
+
+`@plasius/gpu-lighting` already exposes `realtime`, `hybrid`, and `reference`
+profiles, but downstream runtimes still need an explicit contract for when the
+premium `reference` profile should be attempted and when it should step down.
+
+Recent high-end GPUs may be able to hold a reference-first mode at interactive
+rates for some scenes, especially in constrained demos or lighter gameplay
+views. The performance package already owns the adaptive control loop, so the
+lighting package should publish a stable profile ladder that those runtimes can
+hand directly to `@plasius/gpu-performance`.
+
+At the same time, the current pathtracer WGSL files remain placeholder kernels.
+The policy contract must not overstate that implementation status.
+
+## Decision
+
+`@plasius/gpu-lighting` will publish a public adaptive profile ladder contract
+through `createLightingProfileModeLadder()`.
+
+The default policy is:
+
+- start from `reference`
+- use a `4`-frame adaptation window
+- target a `30` FPS floor for keeping `reference`
+- degrade whole-profile quality in this order:
+  - `reference`
+  - `hybrid`
+  - `realtime`
+
+The exported ladder includes:
+
+- ordered profile levels for governor integration
+- a recommended frame-target contract
+- a recommended adaptation-window contract
+- per-level band-planning metadata so renderers can switch profile and lighting
+  participation together
+
+## Consequences
+
+- Positive: the demo, the game, and future renderers can all share one stable
+  reference-first adaptive policy.
+- Positive: high-end devices can legitimately attempt `reference` mode first
+  instead of treating it as offline-only by default.
+- Positive: profile-level degradation becomes explicit and testable rather than
+  ad hoc.
+- Neutral: this ADR defines runtime governance only; it does not claim the
+  placeholder `pathtracer` kernels are already complete realtime ray tracing.
+- Negative: downstream runtimes still need real renderer execution support
+  before this policy can deliver true path-traced pixels.
+
+## Follow-On Work
+
+- Replace placeholder `pathtracer` and hybrid reflection kernels with real WGSL
+  implementations.
+- Teach `@plasius/gpu-renderer` to consume the adaptive lighting profile ladder
+  alongside scene-band planning.
+- Add image-based validation between `reference` and degraded runtime profiles
+  once the real kernels exist.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -6,3 +6,4 @@
 - [Architectural Decision Record (ADR)](./adr-0004:%20HDRI-First%20Physical%20Lighting%20and%20Exposure.md)
 - [Architectural Decision Record (ADR)](./adr-0005:%20Worker-First%20Lighting%20Governance%20Manifest.md)
 - [Architectural Decision Record (ADR)](./adr-0006:%20Distance-Banded%20Lighting%20and%20Shadow%20Sources.md)
+- [Architectural Decision Record (ADR)](./adr-0007:%20Reference-First%20Adaptive%20Lighting%20Profile%20Ladder.md)

--- a/docs/design/pathtracer-and-reflection-kernel-implementation.md
+++ b/docs/design/pathtracer-and-reflection-kernel-implementation.md
@@ -1,0 +1,73 @@
+# Pathtracer And Reflection Kernel Implementation
+
+## Goal
+
+Replace the placeholder WGSL in the `pathtracer` and hybrid
+`reflectionResolve` jobs with real shader logic that downstream runtimes can
+integrate into a true ray-tracing-first renderer.
+
+## Scope
+
+- `src/techniques/pathtracer/pathtrace.job.wgsl`
+- `src/techniques/pathtracer/accumulate.job.wgsl`
+- `src/techniques/pathtracer/denoise.job.wgsl`
+- `src/techniques/hybrid/reflection-resolve.job.wgsl`
+
+## Constraints
+
+- `@plasius/gpu-lighting` is a WGSL catalog and planning package, not the final
+  renderer runtime.
+- The package can define concrete kernels, frame/state structs, and expected
+  storage bindings, but it cannot by itself prove that hardware RT is active in
+  a consumer.
+- The implementation must stay consistent with the existing worker-manifest and
+  technique catalog contracts.
+
+## Proposed Implementation
+
+### Pathtrace job
+
+- Add explicit frame/state structs for camera rays, path-state storage,
+  accumulation targets, and scene inputs.
+- Implement per-pixel jittered sampling.
+- Trace primary rays against a minimal scene contract:
+  - ground plane
+  - analytic spheres
+  - triangle data hooks for future geometry feeds
+- Support configurable bounce depth and throughput accumulation.
+- Produce sky/environment fallback when no hit is found.
+
+### Accumulate job
+
+- Blend the current path-traced sample into a history buffer.
+- Reset accumulation on camera or frame-state invalidation.
+- Track sample counts per pixel so downstream denoise and tone-map stages know
+  the effective convergence level.
+
+### Denoise job
+
+- Replace the placeholder with a spatial-temporal filter that consumes the
+  accumulation buffer plus simple normal/depth guidance.
+- Keep the first version compact and deterministic rather than attempting a full
+  production SVGF implementation immediately.
+
+### Reflection resolve job
+
+- Replace the placeholder with a hybrid resolve that:
+  - reads traced reflection hits and roughness response
+  - falls back to sky/environment lighting when no valid hit exists
+  - applies roughness-aware blur and intensity shaping
+- Keep the resolve logic compatible with the existing `hybrid` technique order.
+
+## Validation
+
+- Add tests that fail if these jobs regress back to placeholders.
+- Assert the new kernels expose expected structs, bindings, and bounce/sample
+  controls.
+- Run package lint, typecheck, coverage, and build after the WGSL updates.
+
+## Non-Goals
+
+- Full renderer-side acceleration structure construction in this package.
+- Claiming production-ready realtime path tracing before `@plasius/gpu-renderer`
+  consumes these kernels end-to-end.

--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,16 @@ export const lightingProfiles = Object.freeze(
 export const lightingProfileNames = Object.freeze(Object.keys(lightingProfiles));
 
 export const defaultLightingProfile = "realtime";
+export const lightingProfileModeOrder = Object.freeze([
+  "realtime",
+  "hybrid",
+  "reference",
+]);
+export const defaultAdaptiveLightingProfilePolicy = Object.freeze({
+  preferredProfile: "reference",
+  minimumFrameRate: 30,
+  sampleWindowSize: 4,
+});
 export const lightingDistanceBands = Object.freeze([
   "near",
   "mid",
@@ -196,6 +206,23 @@ function assertLightingImportance(name, value) {
       `${name} must be one of: ${lightingImportanceLevels.join(", ")}.`
     );
   }
+  return value;
+}
+
+function readPositiveIntegerOption(name, value, fallback) {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    value <= 0 ||
+    Math.round(value) !== value
+  ) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+
   return value;
 }
 
@@ -273,6 +300,93 @@ export function createLightingBandPlan(options = {}) {
     importance,
     techniques: Object.freeze([...profile.techniques]),
     bands,
+  });
+}
+
+const lightingProfileModeEstimatedCostMs = Object.freeze({
+  realtime: 4.5,
+  hybrid: 7.5,
+  reference: 12.5,
+});
+
+export function createLightingProfileModeLadder(options = {}) {
+  const moduleId =
+    typeof options.id === "string" && options.id.trim().length > 0
+      ? options.id.trim()
+      : "lighting-profile-mode";
+  const preferredProfile = getLightingProfile(
+    options.preferredProfile ?? defaultAdaptiveLightingProfilePolicy.preferredProfile
+  ).name;
+  const initialProfile = getLightingProfile(
+    options.initialProfile ?? preferredProfile
+  ).name;
+  const minimumFrameRate = readPositiveIntegerOption(
+    "minimumFrameRate",
+    options.minimumFrameRate,
+    defaultAdaptiveLightingProfilePolicy.minimumFrameRate
+  );
+  const sampleWindowSize = readPositiveIntegerOption(
+    "sampleWindowSize",
+    options.sampleWindowSize,
+    defaultAdaptiveLightingProfilePolicy.sampleWindowSize
+  );
+  const importance = assertLightingImportance(
+    "importance",
+    options.importance ?? "high"
+  );
+  const moduleImportance = assertLightingImportance(
+    "moduleImportance",
+    options.moduleImportance ?? "critical"
+  );
+
+  const levels = Object.freeze(
+    lightingProfileModeOrder.map((profileName) => {
+      const profile = getLightingProfile(profileName);
+      return Object.freeze({
+        id: profile.name,
+        estimatedCostMs: lightingProfileModeEstimatedCostMs[profile.name],
+        config: Object.freeze({
+          profile: profile.name,
+          description: profile.description,
+          techniques: Object.freeze([...profile.techniques]),
+          lightingBandPlan: createLightingBandPlan({
+            profile: profile.name,
+            importance,
+          }),
+          policy: Object.freeze({
+            preferredProfile,
+            minimumFrameRate,
+            sampleWindowSize,
+          }),
+        }),
+      });
+    })
+  );
+
+  return Object.freeze({
+    id: moduleId,
+    domain: "lighting",
+    authority: "visual",
+    importance: moduleImportance,
+    initialLevel: initialProfile,
+    levels,
+    target: Object.freeze({
+      minimumFrameRate,
+      maximumFrameRate: minimumFrameRate,
+      preferredFrameRates: Object.freeze([minimumFrameRate]),
+    }),
+    adaptation: Object.freeze({
+      sampleWindowSize,
+      minimumSamplesBeforeAdjustment: sampleWindowSize,
+      degradeCooldownFrames: 1,
+      upgradeCooldownFrames: sampleWindowSize,
+      minStableFramesForRecovery: sampleWindowSize,
+    }),
+    policy: Object.freeze({
+      preferredProfile,
+      minimumFrameRate,
+      sampleWindowSize,
+    }),
   });
 }
 

--- a/src/techniques/hybrid/prelude.wgsl
+++ b/src/techniques/hybrid/prelude.wgsl
@@ -3,6 +3,14 @@ struct HybridFrameParams {
   max_trace_steps: u32,
   history_weight: f32,
   exposure: f32,
+  image_width: u32,
+  image_height: u32,
+  reflection_reset: u32,
+  sky_mode: u32,
+  sky_intensity: f32,
+  max_reflection_distance: f32,
+  roughness_bias: f32,
+  thickness: f32,
 };
 
 struct HybridHit {
@@ -10,6 +18,115 @@ struct HybridHit {
   hit_distance: f32,
 };
 
+struct HybridReflectionCamera {
+  position: vec3<f32>,
+  _padding0: f32,
+};
+
+struct HybridReflectionSurface {
+  position: vec4<f32>,
+  normal_roughness: vec4<f32>,
+  albedo_metalness: vec4<f32>,
+  emission_occlusion: vec4<f32>,
+};
+
+struct HybridGroundPlane {
+  normal: vec3<f32>,
+  height: f32,
+  material_index: u32,
+  enabled: u32,
+  _padding0: vec2<u32>,
+};
+
+struct HybridReflectionSceneMetadata {
+  sphere_count: u32,
+  material_count: u32,
+  _padding0: vec2<u32>,
+  max_trace_distance: f32,
+};
+
+struct HybridReflectionMaterial {
+  albedo_roughness: vec4<f32>,
+  emission_metalness: vec4<f32>,
+};
+
+struct HybridReflectionSphere {
+  center_radius: vec4<f32>,
+  material_index: u32,
+  flags: u32,
+  _padding0: vec2<u32>,
+};
+
+struct HybridReflectionTrace {
+  hit_mask: u32,
+  distance: f32,
+  position: vec3<f32>,
+  material_index: u32,
+  normal: vec3<f32>,
+  _padding1: u32,
+};
+
+struct HybridReflectionPixel {
+  reflection_confidence: vec4<f32>,
+  hit_normal_distance: vec4<f32>,
+};
+
 fn encode_history_weight(value: f32) -> f32 {
   return clamp(value, 0.0, 1.0);
+}
+
+fn hybrid_saturate(value: f32) -> f32 {
+  return clamp(value, 0.0, 1.0);
+}
+
+fn hybrid_safe_normalize(value: vec3<f32>) -> vec3<f32> {
+  if (dot(value, value) <= 0.000001) {
+    return vec3<f32>(0.0, 1.0, 0.0);
+  }
+
+  return normalize(value);
+}
+
+fn hybrid_fresnel_schlick(cos_theta: f32, f0: vec3<f32>) -> vec3<f32> {
+  let factor = pow(1.0 - hybrid_saturate(cos_theta), 5.0);
+  return f0 + (vec3<f32>(1.0) - f0) * factor;
+}
+
+fn hybrid_hash_u32(value: u32) -> u32 {
+  var x = value + 0x9e3779b9u;
+  x = (x ^ (x >> 16u)) * 0x85ebca6bu;
+  x = (x ^ (x >> 13u)) * 0xc2b2ae35u;
+  return x ^ (x >> 16u);
+}
+
+fn hybrid_random_f32(state: ptr<function, u32>) -> f32 {
+  let next = hybrid_hash_u32((*state) ^ 0x7f4a7c15u);
+  *state = next;
+  return f32(next) * 2.3283064365386963e-10;
+}
+
+fn hybrid_sample_unit_sphere(state: ptr<function, u32>) -> vec3<f32> {
+  let z = hybrid_random_f32(state) * 2.0 - 1.0;
+  let angle = 6.283185307179586 * hybrid_random_f32(state);
+  let radius = sqrt(max(1.0 - z * z, 0.0));
+  return vec3<f32>(radius * cos(angle), radius * sin(angle), z);
+}
+
+fn hybrid_environment(direction: vec3<f32>, intensity: f32, mode: u32) -> vec3<f32> {
+  let up_factor = hybrid_saturate(direction.y * 0.5 + 0.5);
+  let horizon_color = vec3<f32>(0.54, 0.64, 0.77);
+  let zenith_color = select(
+    vec3<f32>(0.04, 0.09, 0.18),
+    vec3<f32>(0.09, 0.07, 0.16),
+    mode == 1u
+  );
+  let sun_direction = hybrid_safe_normalize(vec3<f32>(0.31, 0.92, 0.22));
+  let sun_glow = pow(hybrid_saturate(dot(direction, sun_direction)), 192.0);
+  let sunset_bias = select(vec3<f32>(0.0), vec3<f32>(0.55, 0.24, 0.08) * (1.0 - up_factor), mode == 1u);
+  return (
+    horizon_color * (1.0 - up_factor) +
+    zenith_color * up_factor +
+    sunset_bias +
+    vec3<f32>(5.8, 5.5, 5.0) * sun_glow
+  ) * max(intensity, 0.0001);
 }

--- a/src/techniques/hybrid/reflection-resolve.job.wgsl
+++ b/src/techniques/hybrid/reflection-resolve.job.wgsl
@@ -1,3 +1,236 @@
-fn process_job() {
-  // Placeholder reflection resolve stage for rough/specular response.
+@group(0) @binding(0) var<uniform> hybridFrameParams: HybridFrameParams;
+@group(0) @binding(1) var<uniform> hybridReflectionCamera: HybridReflectionCamera;
+@group(0) @binding(2) var<storage, read> hybridReflectionSurfaces: array<HybridReflectionSurface>;
+@group(0) @binding(3) var<storage, read> hybridReflectionHistory: array<HybridReflectionPixel>;
+@group(0) @binding(4) var<storage, read> hybridReflectionScene: HybridReflectionSceneMetadata;
+@group(0) @binding(5) var<uniform> hybridGroundPlane: HybridGroundPlane;
+@group(0) @binding(6) var<storage, read> hybridReflectionMaterials: array<HybridReflectionMaterial>;
+@group(0) @binding(7) var<storage, read> hybridReflectionSpheres: array<HybridReflectionSphere>;
+@group(0) @binding(8) var<storage, read_write> hybridReflectionOutput: array<HybridReflectionPixel>;
+
+fn reflection_index(pixel: vec2<u32>) -> u32 {
+  return pixel.y * max(hybridFrameParams.image_width, 1u) + pixel.x;
+}
+
+fn unpack_reflection_material(index: u32) -> HybridReflectionMaterial {
+  if (hybridReflectionScene.material_count == 0u) {
+    return HybridReflectionMaterial(
+      vec4<f32>(0.7, 0.72, 0.76, 0.4),
+      vec4<f32>(0.0, 0.0, 0.0, 0.0)
+    );
+  }
+
+  let safe_index = min(index, hybridReflectionScene.material_count - 1u);
+  return hybridReflectionMaterials[safe_index];
+}
+
+fn miss_reflection() -> HybridReflectionTrace {
+  return HybridReflectionTrace(
+    0u,
+    hybridReflectionScene.max_trace_distance,
+    vec3<f32>(0.0),
+    0u,
+    vec3<f32>(0.0, 1.0, 0.0),
+    0u
+  );
+}
+
+fn set_best_reflection(best: ptr<function, HybridReflectionTrace>, candidate: HybridReflectionTrace) {
+  if (candidate.hit_mask == 1u && candidate.distance < (*best).distance) {
+    *best = candidate;
+  }
+}
+
+fn trace_reflection_ground(
+  origin: vec3<f32>,
+  direction: vec3<f32>,
+  best: ptr<function, HybridReflectionTrace>
+) {
+  if (hybridGroundPlane.enabled == 0u) {
+    return;
+  }
+
+  let plane_normal = hybrid_safe_normalize(hybridGroundPlane.normal);
+  let denominator = dot(plane_normal, direction);
+  if (abs(denominator) <= 0.0005) {
+    return;
+  }
+
+  let distance = -(dot(plane_normal, origin) + hybridGroundPlane.height) / denominator;
+  if (distance <= 0.0005 || distance >= (*best).distance || distance >= hybridReflectionScene.max_trace_distance) {
+    return;
+  }
+
+  set_best_reflection(
+    best,
+    HybridReflectionTrace(
+      1u,
+      distance,
+      origin + direction * distance,
+      hybridGroundPlane.material_index,
+      plane_normal,
+      0u
+    )
+  );
+}
+
+fn trace_reflection_spheres(
+  origin: vec3<f32>,
+  direction: vec3<f32>,
+  best: ptr<function, HybridReflectionTrace>
+) {
+  var index = 0u;
+  loop {
+    if (index >= hybridReflectionScene.sphere_count) {
+      break;
+    }
+
+    let sphere = hybridReflectionSpheres[index];
+    let offset = origin - sphere.center_radius.xyz;
+    let a = dot(direction, direction);
+    let half_b = dot(offset, direction);
+    let c = dot(offset, offset) - sphere.center_radius.w * sphere.center_radius.w;
+    let discriminant = half_b * half_b - a * c;
+    if (discriminant >= 0.0) {
+      let root = sqrt(discriminant);
+      var distance = (-half_b - root) / max(a, 0.0005);
+      if (distance <= 0.0005) {
+        distance = (-half_b + root) / max(a, 0.0005);
+      }
+      if (distance > 0.0005 && distance < (*best).distance && distance < hybridReflectionScene.max_trace_distance) {
+        let position = origin + direction * distance;
+        let normal = hybrid_safe_normalize(position - sphere.center_radius.xyz);
+        set_best_reflection(
+          best,
+          HybridReflectionTrace(
+            1u,
+            distance,
+            position,
+            sphere.material_index,
+            normal,
+            0u
+          )
+        );
+      }
+    }
+
+    index = index + 1u;
+  }
+}
+
+fn trace_reflection_scene(origin: vec3<f32>, direction: vec3<f32>) -> HybridReflectionTrace {
+  var best = miss_reflection();
+  trace_reflection_ground(origin, direction, &best);
+  trace_reflection_spheres(origin, direction, &best);
+  return best;
+}
+
+fn evaluate_hit_lighting(trace: HybridReflectionTrace, view_direction: vec3<f32>) -> vec3<f32> {
+  let material = unpack_reflection_material(trace.material_index);
+  let surface_normal = hybrid_safe_normalize(trace.normal);
+  let light_direction = hybrid_safe_normalize(vec3<f32>(0.31, 0.92, 0.22));
+  let ndotl = hybrid_saturate(dot(surface_normal, light_direction));
+  let halfway = hybrid_safe_normalize(light_direction + view_direction);
+  let roughness = clamp(material.albedo_roughness.w, 0.02, 1.0);
+  let metalness = hybrid_saturate(material.emission_metalness.w);
+  let albedo = material.albedo_roughness.xyz;
+  let f0 = vec3<f32>(0.04) * (1.0 - metalness) + albedo * metalness;
+  let fresnel = hybrid_fresnel_schlick(
+    hybrid_saturate(dot(surface_normal, view_direction)),
+    f0
+  );
+  let diffuse = albedo * ndotl * 0.3183098861837907 * (1.0 - metalness);
+  let specular_power = 12.0 + (1.0 - roughness) * 96.0;
+  let specular = fresnel * pow(hybrid_saturate(dot(surface_normal, halfway)), specular_power) * ndotl;
+  let direct_light = vec3<f32>(5.4, 5.0, 4.6) * ndotl;
+  let environment = hybrid_environment(surface_normal, hybridFrameParams.sky_intensity, hybridFrameParams.sky_mode);
+  return material.emission_metalness.xyz + (diffuse + specular) * direct_light + environment * 0.08;
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn process_job(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  if (
+    global_id.x >= hybridFrameParams.image_width ||
+    global_id.y >= hybridFrameParams.image_height
+  ) {
+    return;
+  }
+
+  let index = reflection_index(global_id.xy);
+  let surface = hybridReflectionSurfaces[index];
+  let previous = hybridReflectionHistory[index];
+  let position = surface.position.xyz;
+  let normal = hybrid_safe_normalize(surface.normal_roughness.xyz);
+  let roughness = clamp(surface.normal_roughness.w + hybridFrameParams.roughness_bias, 0.02, 1.0);
+  let albedo = surface.albedo_metalness.xyz;
+  let metalness = hybrid_saturate(surface.albedo_metalness.w);
+  let occlusion = hybrid_saturate(surface.emission_occlusion.w);
+  let view_direction = hybrid_safe_normalize(hybridReflectionCamera.position - position);
+  let f0 = vec3<f32>(0.04) * (1.0 - metalness) + albedo * metalness;
+  let fresnel = hybrid_fresnel_schlick(hybrid_saturate(dot(normal, view_direction)), f0);
+  let grazing_boost = pow(1.0 - hybrid_saturate(dot(normal, view_direction)), 5.0);
+  let reflection_budget = clamp(
+    (metalness * 0.85 + max(fresnel.x, max(fresnel.y, fresnel.z))) *
+      (1.0 - roughness * 0.65) +
+      grazing_boost * 0.2,
+    0.0,
+    1.0
+  );
+  let trace_needed = reflection_budget > 0.02;
+  var random_state = hybrid_hash_u32(
+    hybridFrameParams.frame_index * 747796405u +
+    index * 2891336453u +
+    0x27d4eb2du
+  );
+  let reflection_direction = hybrid_safe_normalize(
+    reflect(-view_direction, normal) +
+      hybrid_sample_unit_sphere(&random_state) * roughness * roughness * 0.35
+  );
+  var trace = miss_reflection();
+  if (trace_needed) {
+    trace = trace_reflection_scene(
+      position + normal * max(hybridFrameParams.thickness, 0.0005),
+      reflection_direction
+    );
+  }
+  let hit_radiance = select(
+    hybrid_environment(reflection_direction, hybridFrameParams.sky_intensity, hybridFrameParams.sky_mode),
+    evaluate_hit_lighting(trace, -reflection_direction),
+    trace.hit_mask == 1u
+  );
+  let roughness_mix = roughness * roughness;
+  let distant_fade = exp(
+    -trace.distance /
+      max(hybridFrameParams.max_reflection_distance * 0.65, 0.0005)
+  );
+  let reflection_color =
+    hit_radiance * reflection_budget * distant_fade * occlusion;
+  let sky_lobe = hybrid_environment(normal, hybridFrameParams.sky_intensity, hybridFrameParams.sky_mode);
+  let shaped_reflection =
+    reflection_color * (1.0 - roughness_mix * 0.35) +
+    sky_lobe * roughness_mix * 0.18 * reflection_budget;
+  let history_weight = select(
+    0.0,
+    encode_history_weight(hybridFrameParams.history_weight),
+    hybridFrameParams.reflection_reset == 0u && previous.reflection_confidence.w > 0.0
+  );
+  let resolved =
+    previous.reflection_confidence.xyz * history_weight +
+    shaped_reflection * (1.0 - history_weight);
+  let confidence = clamp(
+    reflection_budget * (0.45 + distant_fade * 0.55) * (1.0 - roughness * 0.35),
+    0.0,
+    1.0
+  );
+  let resolved_normal = select(normal, hybrid_safe_normalize(trace.normal), trace.hit_mask == 1u);
+  let resolved_distance = select(
+    hybridFrameParams.max_reflection_distance,
+    trace.distance,
+    trace.hit_mask == 1u
+  );
+
+  hybridReflectionOutput[index] = HybridReflectionPixel(
+    vec4<f32>(resolved * hybridFrameParams.exposure, confidence),
+    vec4<f32>(resolved_normal, resolved_distance)
+  );
 }

--- a/src/techniques/pathtracer/accumulate.job.wgsl
+++ b/src/techniques/pathtracer/accumulate.job.wgsl
@@ -1,3 +1,65 @@
-fn process_job() {
-  // Placeholder progressive accumulation stage.
+@group(0) @binding(0) var<uniform> pathTracerParams: PathTracerParams;
+@group(0) @binding(1) var<storage, read> pathSampleBuffer: array<PathSamplePixel>;
+@group(0) @binding(2) var<storage, read_write> pathAccumulationBuffer: array<PathAccumulationPixel>;
+
+fn accumulation_index(pixel: vec2<u32>) -> u32 {
+  return pixel.y * max(pathTracerParams.image_width, 1u) + pixel.x;
+}
+
+fn reset_accumulation(sample: PathSamplePixel) -> PathAccumulationPixel {
+  let sample_luminance = luminance(sample.radiance_opacity.xyz);
+  return PathAccumulationPixel(
+    vec4<f32>(sample.radiance_opacity.xyz, max(sample.albedo_sample_count.w, 1.0)),
+    vec4<f32>(sample_luminance, 0.0, 0.0, f32(pathTracerParams.frame_index))
+  );
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn process_job(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  if (
+    global_id.x >= pathTracerParams.image_width ||
+    global_id.y >= pathTracerParams.image_height
+  ) {
+    return;
+  }
+
+  let index = accumulation_index(global_id.xy);
+  let sample = pathSampleBuffer[index];
+  let history = pathAccumulationBuffer[index];
+  let sample_luminance = luminance(sample.radiance_opacity.xyz);
+  let current_samples = max(sample.albedo_sample_count.w, 1.0);
+  let history_samples = max(history.integrated_radiance.w, 0.0);
+  let should_reset =
+    pathTracerParams.accumulation_reset != 0u ||
+    history_samples <= 0.0 ||
+    history.moments.w <= 0.0;
+
+  if (should_reset) {
+    pathAccumulationBuffer[index] = reset_accumulation(sample);
+    return;
+  }
+
+  let combined_samples = min(history_samples + current_samples, 4096.0);
+  let progressive_weight = current_samples / max(combined_samples, 1.0);
+  let minimum_refresh = 1.0 - clamp(pathTracerParams.history_blend, 0.0, 0.98);
+  let blend = clamp(max(progressive_weight, minimum_refresh), 0.02, 1.0);
+  let integrated =
+    history.integrated_radiance.xyz * (1.0 - blend) +
+    sample.radiance_opacity.xyz * blend;
+  let mean_luminance =
+    history.moments.x * (1.0 - blend) +
+    sample_luminance * blend;
+  let variance_sample = sample_luminance - mean_luminance;
+  let variance =
+    max(0.0, history.moments.y * (1.0 - blend) + variance_sample * variance_sample * blend);
+
+  pathAccumulationBuffer[index] = PathAccumulationPixel(
+    vec4<f32>(integrated, combined_samples),
+    vec4<f32>(
+      mean_luminance,
+      variance,
+      1.0 - blend,
+      f32(pathTracerParams.frame_index)
+    )
+  );
 }

--- a/src/techniques/pathtracer/denoise.job.wgsl
+++ b/src/techniques/pathtracer/denoise.job.wgsl
@@ -1,3 +1,126 @@
-fn process_job() {
-  // Placeholder denoise stage for interactive reference previews.
+@group(0) @binding(0) var<uniform> pathTracerParams: PathTracerParams;
+@group(0) @binding(1) var<storage, read> pathAccumulationBuffer: array<PathAccumulationPixel>;
+@group(0) @binding(2) var<storage, read> pathSampleBuffer: array<PathSamplePixel>;
+@group(0) @binding(3) var<storage, read_write> pathDenoiseHistoryBuffer: array<PathDenoisePixel>;
+
+fn denoise_index(pixel: vec2<u32>) -> u32 {
+  return pixel.y * max(pathTracerParams.image_width, 1u) + pixel.x;
+}
+
+fn in_bounds(pixel: vec2<i32>) -> bool {
+  return
+    pixel.x >= 0 &&
+    pixel.y >= 0 &&
+    pixel.x < i32(pathTracerParams.image_width) &&
+    pixel.y < i32(pathTracerParams.image_height);
+}
+
+fn spatial_kernel(offset: vec2<i32>) -> f32 {
+  if (offset.x == 0 && offset.y == 0) {
+    return 4.0;
+  }
+  if (offset.x == 0 || offset.y == 0) {
+    return 2.0;
+  }
+  return 1.0;
+}
+
+fn bilateral_weight(
+  center_sample: PathSamplePixel,
+  center_accumulation: PathAccumulationPixel,
+  neighbor_sample: PathSamplePixel,
+  offset: vec2<i32>
+) -> f32 {
+  let strength = clamp(pathTracerParams.denoise_strength, 0.0, 1.0);
+  let center_normal = safe_normalize(center_sample.normal_roughness.xyz);
+  let neighbor_normal = safe_normalize(neighbor_sample.normal_roughness.xyz);
+  let normal_alignment = pow(
+    saturate(dot(center_normal, neighbor_normal)),
+    6.0 + (1.0 - strength) * 24.0
+  );
+  let depth_delta = abs(center_sample.direction_distance.w - neighbor_sample.direction_distance.w);
+  let depth_scale =
+    max(center_sample.direction_distance.w, 1.0) *
+    (0.01 + strength * 0.04);
+  let depth_weight = exp(-depth_delta * safe_rcp(depth_scale));
+  let albedo_delta = length(
+    center_sample.albedo_sample_count.xyz - neighbor_sample.albedo_sample_count.xyz
+  );
+  let albedo_weight = exp(-albedo_delta * (2.0 + strength * 2.0));
+  let sample_weight = clamp(
+    neighbor_sample.albedo_sample_count.w /
+      max(center_sample.albedo_sample_count.w, 1.0),
+    0.25,
+    1.5
+  );
+  let variance_penalty = 1.0 / (1.0 + center_accumulation.moments.y * 0.5);
+  return spatial_kernel(offset) *
+    max(normal_alignment * depth_weight * albedo_weight * sample_weight * variance_penalty, 0.0001);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn process_job(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  if (
+    global_id.x >= pathTracerParams.image_width ||
+    global_id.y >= pathTracerParams.image_height
+  ) {
+    return;
+  }
+
+  let pixel = vec2<i32>(i32(global_id.x), i32(global_id.y));
+  let index = denoise_index(global_id.xy);
+  let center_accumulation = pathAccumulationBuffer[index];
+  let center_sample = pathSampleBuffer[index];
+  let center_history = pathDenoiseHistoryBuffer[index];
+  var filtered = vec3<f32>(0.0);
+  var total_weight = 0.0;
+
+  for (var y = -1; y <= 1; y = y + 1) {
+    for (var x = -1; x <= 1; x = x + 1) {
+      let neighbor_pixel = pixel + vec2<i32>(x, y);
+      if (!in_bounds(neighbor_pixel)) {
+        continue;
+      }
+
+      let neighbor_index = denoise_index(vec2<u32>(u32(neighbor_pixel.x), u32(neighbor_pixel.y)));
+      let neighbor_accumulation = pathAccumulationBuffer[neighbor_index];
+      let neighbor_sample = pathSampleBuffer[neighbor_index];
+      let weight = bilateral_weight(
+        center_sample,
+        center_accumulation,
+        neighbor_sample,
+        vec2<i32>(x, y)
+      );
+      filtered = filtered + neighbor_accumulation.integrated_radiance.xyz * weight;
+      total_weight = total_weight + weight;
+    }
+  }
+
+  let filtered_color = filtered / max(total_weight, PATH_TRACER_EPSILON);
+  let sample_confidence = clamp(
+    log2(max(center_accumulation.integrated_radiance.w, 1.0) + 1.0) / 6.0,
+    0.0,
+    1.0
+  );
+  let variance_penalty = 1.0 / (1.0 + center_accumulation.moments.y * 0.75);
+  let confidence = clamp(sample_confidence * variance_penalty, 0.0, 1.0);
+  let use_history =
+    pathTracerParams.accumulation_reset == 0u &&
+    center_history.filtered_radiance.w > 0.0;
+  let temporal_blend = clamp(0.2 + confidence * 0.6, 0.2, 0.9);
+  let resolved_color = select(
+    filtered_color,
+    center_history.filtered_radiance.xyz * (1.0 - temporal_blend) +
+      filtered_color * temporal_blend,
+    use_history
+  );
+
+  pathDenoiseHistoryBuffer[index] = PathDenoisePixel(
+    vec4<f32>(resolved_color, confidence),
+    vec4<f32>(safe_normalize(center_sample.normal_roughness.xyz), center_sample.direction_distance.w),
+    vec4<f32>(
+      center_sample.albedo_sample_count.xyz,
+      center_accumulation.integrated_radiance.w
+    )
+  );
 }

--- a/src/techniques/pathtracer/pathtrace.job.wgsl
+++ b/src/techniques/pathtracer/pathtrace.job.wgsl
@@ -1,3 +1,430 @@
-fn process_job() {
-  // Placeholder path tracing kernel for reference rendering.
+@group(0) @binding(0) var<uniform> pathTracerParams: PathTracerParams;
+@group(0) @binding(1) var<uniform> pathTracerCamera: PathTracerCamera;
+@group(0) @binding(2) var<storage, read> pathTracerScene: PathTracerSceneMetadata;
+@group(0) @binding(3) var<uniform> pathTracerGroundPlane: PathTracerGroundPlane;
+@group(0) @binding(4) var<storage, read> pathTracerMaterials: array<PathTracerMaterial>;
+@group(0) @binding(5) var<storage, read> pathTracerSpheres: array<PathTracerSphere>;
+@group(0) @binding(6) var<storage, read> pathTracerTriangles: array<PathTracerTriangle>;
+@group(0) @binding(7) var<storage, read_write> pathStateBuffer: array<PathState>;
+@group(0) @binding(8) var<storage, read_write> pathSampleBuffer: array<PathSamplePixel>;
+
+fn pixel_index(pixel: vec2<u32>) -> u32 {
+  return pixel.y * max(pathTracerParams.image_width, 1u) + pixel.x;
+}
+
+fn load_path_material(index: u32) -> MaterialSample {
+  if (pathTracerScene.material_count == 0u) {
+    return unpack_material(make_default_material());
+  }
+
+  let safe_index = min(index, pathTracerScene.material_count - 1u);
+  return unpack_material(pathTracerMaterials[safe_index]);
+}
+
+fn set_best_hit(best: ptr<function, PathHit>, candidate: PathHit) {
+  if (candidate.hit == 1u && candidate.distance < (*best).distance) {
+    *best = candidate;
+  }
+}
+
+fn trace_ground(ray: Ray, best: ptr<function, PathHit>) {
+  if (pathTracerGroundPlane.enabled == 0u) {
+    return;
+  }
+
+  let plane_normal = safe_normalize(pathTracerGroundPlane.normal);
+  let denominator = dot(plane_normal, ray.direction);
+  if (abs(denominator) <= PATH_TRACER_EPSILON) {
+    return;
+  }
+
+  let distance = -(dot(plane_normal, ray.origin) + pathTracerGroundPlane.height) / denominator;
+  if (distance <= ray.t_min || distance >= (*best).distance || distance >= ray.t_max) {
+    return;
+  }
+
+  set_best_hit(
+    best,
+    PathHit(
+      1u,
+      distance,
+      ray.origin + ray.direction * distance,
+      pathTracerGroundPlane.material_index,
+      plane_normal,
+      1u,
+      vec3<f32>(1.0, 0.0, 0.0),
+      0u
+    )
+  );
+}
+
+fn trace_spheres(ray: Ray, best: ptr<function, PathHit>) {
+  var index = 0u;
+  loop {
+    if (index >= pathTracerScene.sphere_count) {
+      break;
+    }
+
+    let sphere = pathTracerSpheres[index];
+    let offset = ray.origin - sphere.center_radius.xyz;
+    let a = dot(ray.direction, ray.direction);
+    let half_b = dot(offset, ray.direction);
+    let c = dot(offset, offset) - sphere.center_radius.w * sphere.center_radius.w;
+    let discriminant = half_b * half_b - a * c;
+    if (discriminant >= 0.0) {
+      let root = sqrt(discriminant);
+      var distance = (-half_b - root) / max(a, PATH_TRACER_EPSILON);
+      if (distance <= ray.t_min) {
+        distance = (-half_b + root) / max(a, PATH_TRACER_EPSILON);
+      }
+      if (distance > ray.t_min && distance < (*best).distance && distance < ray.t_max) {
+        let position = ray.origin + ray.direction * distance;
+        let normal = safe_normalize(position - sphere.center_radius.xyz);
+        set_best_hit(
+          best,
+          PathHit(
+            1u,
+            distance,
+            position,
+            sphere.material_index,
+            normal,
+            2u,
+            vec3<f32>(0.0),
+            0u
+          )
+        );
+      }
+    }
+
+    index = index + 1u;
+  }
+}
+
+fn trace_triangles(ray: Ray, best: ptr<function, PathHit>) {
+  var index = 0u;
+  loop {
+    if (index >= pathTracerScene.triangle_count) {
+      break;
+    }
+
+    let triangle = pathTracerTriangles[index];
+    let p0 = triangle.position0.xyz;
+    let p1 = triangle.position1.xyz;
+    let p2 = triangle.position2.xyz;
+    let edge1 = p1 - p0;
+    let edge2 = p2 - p0;
+    let p_vec = cross(ray.direction, edge2);
+    let determinant = dot(edge1, p_vec);
+    if (abs(determinant) > PATH_TRACER_EPSILON) {
+      let inverse_determinant = 1.0 / determinant;
+      let t_vec = ray.origin - p0;
+      let u = dot(t_vec, p_vec) * inverse_determinant;
+      if (u >= 0.0 && u <= 1.0) {
+        let q_vec = cross(t_vec, edge1);
+        let v = dot(ray.direction, q_vec) * inverse_determinant;
+        if (v >= 0.0 && u + v <= 1.0) {
+          let distance = dot(edge2, q_vec) * inverse_determinant;
+          if (distance > ray.t_min && distance < (*best).distance && distance < ray.t_max) {
+            let w = 1.0 - u - v;
+            let interpolated_normal =
+              triangle.normal0.xyz * w +
+              triangle.normal1.xyz * u +
+              triangle.normal2.xyz * v;
+            let geometric_normal = cross(edge1, edge2);
+            let resolved_normal = select(
+              safe_normalize(geometric_normal),
+              safe_normalize(interpolated_normal),
+              dot(interpolated_normal, interpolated_normal) > PATH_TRACER_EPSILON
+            );
+            set_best_hit(
+              best,
+              PathHit(
+                1u,
+                distance,
+                ray.origin + ray.direction * distance,
+                triangle.material_index,
+                resolved_normal,
+                3u,
+                vec3<f32>(w, u, v),
+                0u
+              )
+            );
+          }
+        }
+      }
+    }
+
+    index = index + 1u;
+  }
+}
+
+fn trace_scene(ray: Ray) -> PathHit {
+  var best = miss_hit(ray);
+  trace_ground(ray, &best);
+  trace_spheres(ray, &best);
+  trace_triangles(ray, &best);
+  return best;
+}
+
+fn trace_shadow(origin: vec3<f32>, direction: vec3<f32>, max_distance: f32) -> bool {
+  let shadow_ray = Ray(
+    origin + direction * PATH_TRACER_EPSILON * 8.0,
+    PATH_TRACER_EPSILON,
+    direction,
+    max_distance
+  );
+  return trace_scene(shadow_ray).hit == 1u;
+}
+
+fn evaluate_direct_sun(
+  hit: PathHit,
+  material: MaterialSample,
+  view_direction: vec3<f32>
+) -> vec3<f32> {
+  let surface_normal = faceforward_normal(hit.normal, -view_direction);
+  let sun_direction = safe_normalize(vec3<f32>(0.32, 0.91, 0.21));
+  let ndotl = saturate(dot(surface_normal, sun_direction));
+  if (ndotl <= 0.0) {
+    return vec3<f32>(0.0);
+  }
+
+  let shadowed = trace_shadow(hit.position + surface_normal * PATH_TRACER_EPSILON * 12.0, sun_direction, pathTracerScene.max_trace_distance);
+  if (shadowed) {
+    return vec3<f32>(0.0);
+  }
+
+  let halfway = safe_normalize(sun_direction + view_direction);
+  let base_reflectance =
+    vec3<f32>(0.04) * (1.0 - material.metalness) +
+    material.albedo * material.metalness;
+  let fresnel = fresnel_schlick(saturate(dot(surface_normal, view_direction)), base_reflectance);
+  let specular_power = 8.0 + (1.0 - material.roughness) * 120.0;
+  let specular = fresnel * pow(saturate(dot(surface_normal, halfway)), specular_power) * ndotl;
+  let diffuse =
+    material.albedo *
+    ndotl *
+    PATH_TRACER_INV_PI *
+    (1.0 - material.metalness);
+  let sun_color = vec3<f32>(10.0, 9.4, 8.6) * max(pathTracerParams.environment_intensity, 0.0001);
+  return (diffuse + specular) * sun_color;
+}
+
+fn sample_scatter(
+  surface_normal: vec3<f32>,
+  material: MaterialSample,
+  view_direction: vec3<f32>,
+  random_state: ptr<function, u32>
+) -> PathScatter {
+  let specular_chance = clamp(
+    material.metalness * 0.75 + (1.0 - material.roughness) * 0.35,
+    0.05,
+    0.95
+  );
+  let choose_specular = random_f32(random_state) < specular_chance;
+  let base_reflectance =
+    vec3<f32>(0.04) * (1.0 - material.metalness) +
+    material.albedo * material.metalness;
+
+  if (choose_specular) {
+    let reflected = reflect(-view_direction, surface_normal);
+    let glossy_direction = safe_normalize(
+      reflected + sample_unit_sphere(random_state) * material.roughness * 0.35
+    );
+    let attenuation = fresnel_schlick(
+      saturate(dot(surface_normal, view_direction)),
+      base_reflectance
+    ) / specular_chance;
+    return PathScatter(glossy_direction, 1.0, attenuation, 1.0);
+  }
+
+  let diffuse_direction = sample_cosine_hemisphere(surface_normal, random_state);
+  let cosine = saturate(dot(surface_normal, diffuse_direction));
+  let pdf = max(cosine * PATH_TRACER_INV_PI, PATH_TRACER_EPSILON);
+  let attenuation =
+    material.albedo *
+    (1.0 - material.metalness) *
+    cosine /
+    max((1.0 - specular_chance) * pdf, PATH_TRACER_EPSILON);
+  return PathScatter(diffuse_direction, pdf, attenuation, 0.0);
+}
+
+fn make_camera_ray(pixel: vec2<u32>, jitter: vec2<f32>, random_state: ptr<function, u32>) -> Ray {
+  let image_size = vec2<f32>(
+    max(f32(pathTracerParams.image_width), 1.0),
+    max(f32(pathTracerParams.image_height), 1.0)
+  );
+  let uv = ((vec2<f32>(pixel) + jitter) / image_size) * 2.0 - vec2<f32>(1.0, 1.0);
+  let tan_half_fov = tan(pathTracerCamera.vertical_fov_radians * 0.5);
+  let sensor_offset =
+    pathTracerCamera.right * uv.x * pathTracerCamera.aspect_ratio * tan_half_fov +
+    pathTracerCamera.up * (-uv.y) * tan_half_fov;
+  let focal_point =
+    pathTracerCamera.origin +
+    (pathTracerCamera.forward + sensor_offset) * pathTracerCamera.focus_distance;
+  var origin = pathTracerCamera.origin;
+  if (pathTracerCamera.aperture_radius > 0.0) {
+    let lens = sample_unit_disk(random_state) * pathTracerCamera.aperture_radius;
+    origin =
+      origin +
+      pathTracerCamera.right * lens.x +
+      pathTracerCamera.up * lens.y;
+  }
+  return Ray(
+    origin,
+    PATH_TRACER_EPSILON,
+    safe_normalize(focal_point - origin),
+    pathTracerScene.max_trace_distance
+  );
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn process_job(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  if (
+    global_id.x >= pathTracerParams.image_width ||
+    global_id.y >= pathTracerParams.image_height
+  ) {
+    return;
+  }
+
+  let pixel = global_id.xy;
+  let index = pixel_index(pixel);
+  let sample_count = max(pathTracerParams.samples_per_pixel, 1u);
+  let bounce_count = max(pathTracerParams.max_bounces, 1u);
+  var random_state = hash_u32(
+    pathTracerParams.frame_index * 1664525u +
+    index * 1013904223u +
+    0x6d2b79f5u
+  );
+  var accumulated_radiance = vec3<f32>(0.0);
+  var accumulated_normal = vec3<f32>(0.0);
+  var accumulated_albedo = vec3<f32>(0.0);
+  var accumulated_distance = 0.0;
+  var accumulated_roughness = 0.0;
+  var primary_direction = vec3<f32>(0.0, 0.0, 1.0);
+  var terminal_direction = primary_direction;
+  var terminal_origin = pathTracerCamera.origin;
+  var terminal_throughput = vec3<f32>(1.0);
+  var last_hit_kind = 0u;
+  var hit_samples = 0.0;
+
+  for (var sample_index = 0u; sample_index < sample_count; sample_index = sample_index + 1u) {
+    let jitter = vec2<f32>(random_f32(&random_state), random_f32(&random_state));
+    var ray = make_camera_ray(pixel, jitter, &random_state);
+    primary_direction = primary_direction + ray.direction;
+    var throughput = vec3<f32>(1.0);
+    var sample_radiance = vec3<f32>(0.0);
+    var captured_primary_hit = false;
+    var current_hit_kind = 0u;
+
+    for (var bounce_index = 0u; bounce_index < bounce_count; bounce_index = bounce_index + 1u) {
+      let hit = trace_scene(ray);
+      if (hit.hit == 0u) {
+        sample_radiance = sample_radiance + throughput * environment_radiance(
+          ray.direction,
+          pathTracerParams.environment_intensity,
+          pathTracerParams.environment_mode
+        );
+        terminal_origin = ray.origin;
+        terminal_direction = ray.direction;
+        current_hit_kind = 0u;
+        break;
+      }
+
+      let material = load_path_material(hit.material_index);
+      let surface_normal = faceforward_normal(hit.normal, ray.direction);
+
+      if (!captured_primary_hit) {
+        accumulated_normal = accumulated_normal + surface_normal;
+        accumulated_distance = accumulated_distance + hit.distance;
+        accumulated_albedo = accumulated_albedo + material.albedo;
+        accumulated_roughness = accumulated_roughness + material.roughness;
+        hit_samples = hit_samples + 1.0;
+        captured_primary_hit = true;
+      }
+
+      sample_radiance = sample_radiance + throughput * material.emission;
+      if (pathTracerParams.enable_next_event_estimation != 0u) {
+        sample_radiance = sample_radiance + throughput * evaluate_direct_sun(
+          hit,
+          material,
+          -ray.direction
+        );
+      }
+
+      let scatter = sample_scatter(surface_normal, material, -ray.direction, &random_state);
+      throughput = throughput * scatter.attenuation;
+      if (luminance(throughput) <= 0.0001) {
+        terminal_origin = hit.position;
+        terminal_direction = scatter.direction;
+        current_hit_kind = hit.primitive_kind;
+        break;
+      }
+
+      if (bounce_index >= 2u) {
+        let russian_roulette = clamp(luminance(throughput), 0.05, 0.95);
+        if (random_f32(&random_state) > russian_roulette) {
+          terminal_origin = hit.position;
+          terminal_direction = scatter.direction;
+          current_hit_kind = hit.primitive_kind;
+          break;
+        }
+        throughput = throughput / russian_roulette;
+      }
+
+      ray = Ray(
+        hit.position + scatter.direction * PATH_TRACER_EPSILON * 8.0,
+        PATH_TRACER_EPSILON,
+        scatter.direction,
+        pathTracerScene.max_trace_distance
+      );
+      terminal_origin = ray.origin;
+      terminal_direction = ray.direction;
+      current_hit_kind = hit.primitive_kind;
+    }
+
+    terminal_throughput = throughput;
+    last_hit_kind = max(last_hit_kind, current_hit_kind);
+    accumulated_radiance = accumulated_radiance + sample_radiance;
+  }
+
+  let sample_count_f32 = f32(sample_count);
+  let averaged_radiance = accumulated_radiance / sample_count_f32;
+  let averaged_direction = safe_normalize(primary_direction / sample_count_f32);
+  let averaged_normal = select(
+    vec3<f32>(0.0, 1.0, 0.0),
+    safe_normalize(accumulated_normal / max(hit_samples, 1.0)),
+    hit_samples > 0.0
+  );
+  let averaged_distance = select(
+    pathTracerScene.max_trace_distance,
+    accumulated_distance / max(hit_samples, 1.0),
+    hit_samples > 0.0
+  );
+  let averaged_albedo = select(
+    vec3<f32>(0.0),
+    accumulated_albedo / max(hit_samples, 1.0),
+    hit_samples > 0.0
+  );
+  let averaged_roughness = select(
+    1.0,
+    accumulated_roughness / max(hit_samples, 1.0),
+    hit_samples > 0.0
+  );
+  let hit_mask = select(0.0, 1.0, hit_samples > 0.0);
+
+  pathStateBuffer[index] = PathState(
+    vec4<f32>(terminal_throughput, f32(bounce_count)),
+    vec4<f32>(terminal_origin, hit_mask),
+    vec4<f32>(terminal_direction, 1.0),
+    random_state,
+    last_hit_kind,
+    vec2<u32>(0u)
+  );
+
+  pathSampleBuffer[index] = PathSamplePixel(
+    vec4<f32>(averaged_radiance * pathTracerParams.exposure, hit_mask),
+    vec4<f32>(averaged_direction, averaged_distance),
+    vec4<f32>(averaged_normal, averaged_roughness),
+    vec4<f32>(averaged_albedo, sample_count_f32)
+  );
 }

--- a/src/techniques/pathtracer/prelude.wgsl
+++ b/src/techniques/pathtracer/prelude.wgsl
@@ -1,8 +1,20 @@
+const PATH_TRACER_PI: f32 = 3.141592653589793;
+const PATH_TRACER_INV_PI: f32 = 0.3183098861837907;
+const PATH_TRACER_EPSILON: f32 = 0.0005;
+
 struct PathTracerParams {
   frame_index: u32,
   max_bounces: u32,
   samples_per_pixel: u32,
   enable_next_event_estimation: u32,
+  image_width: u32,
+  image_height: u32,
+  accumulation_reset: u32,
+  environment_mode: u32,
+  environment_intensity: f32,
+  exposure: f32,
+  history_blend: f32,
+  denoise_strength: f32,
 };
 
 struct PathSample {
@@ -10,6 +22,254 @@ struct PathSample {
   throughput: vec3<f32>,
 };
 
+struct PathTracerCamera {
+  origin: vec3<f32>,
+  aspect_ratio: f32,
+  forward: vec3<f32>,
+  vertical_fov_radians: f32,
+  right: vec3<f32>,
+  focus_distance: f32,
+  up: vec3<f32>,
+  aperture_radius: f32,
+};
+
+struct PathTracerSceneMetadata {
+  sphere_count: u32,
+  triangle_count: u32,
+  material_count: u32,
+  max_trace_distance: f32,
+};
+
+struct PathTracerGroundPlane {
+  normal: vec3<f32>,
+  height: f32,
+  material_index: u32,
+  enabled: u32,
+  _padding0: vec2<u32>,
+};
+
+struct PathTracerMaterial {
+  albedo_roughness: vec4<f32>,
+  emission_metalness: vec4<f32>,
+  transmittance_ior: vec4<f32>,
+};
+
+struct PathTracerSphere {
+  center_radius: vec4<f32>,
+  material_index: u32,
+  flags: u32,
+  _padding0: vec2<u32>,
+};
+
+struct PathTracerTriangle {
+  position0: vec4<f32>,
+  position1: vec4<f32>,
+  position2: vec4<f32>,
+  normal0: vec4<f32>,
+  normal1: vec4<f32>,
+  normal2: vec4<f32>,
+  material_index: u32,
+  flags: u32,
+  _padding0: vec2<u32>,
+};
+
+struct Ray {
+  origin: vec3<f32>,
+  t_min: f32,
+  direction: vec3<f32>,
+  t_max: f32,
+};
+
+struct PathHit {
+  hit: u32,
+  distance: f32,
+  position: vec3<f32>,
+  material_index: u32,
+  normal: vec3<f32>,
+  primitive_kind: u32,
+  barycentric: vec3<f32>,
+  _padding1: u32,
+};
+
+struct MaterialSample {
+  albedo: vec3<f32>,
+  roughness: f32,
+  emission: vec3<f32>,
+  metalness: f32,
+  transmittance: vec3<f32>,
+  refractive_index: f32,
+};
+
+struct PathScatter {
+  direction: vec3<f32>,
+  pdf: f32,
+  attenuation: vec3<f32>,
+  event_kind: f32,
+};
+
+struct PathState {
+  throughput_bounce: vec4<f32>,
+  origin_active: vec4<f32>,
+  direction_pdf: vec4<f32>,
+  random_state: u32,
+  last_hit_kind: u32,
+  _padding0: vec2<u32>,
+};
+
+struct PathSamplePixel {
+  radiance_opacity: vec4<f32>,
+  direction_distance: vec4<f32>,
+  normal_roughness: vec4<f32>,
+  albedo_sample_count: vec4<f32>,
+};
+
+struct PathAccumulationPixel {
+  integrated_radiance: vec4<f32>,
+  moments: vec4<f32>,
+};
+
+struct PathDenoisePixel {
+  filtered_radiance: vec4<f32>,
+  normal_depth: vec4<f32>,
+  albedo_history: vec4<f32>,
+};
+
 fn luminance(value: vec3<f32>) -> f32 {
   return dot(value, vec3<f32>(0.2126, 0.7152, 0.0722));
+}
+
+fn saturate(value: f32) -> f32 {
+  return clamp(value, 0.0, 1.0);
+}
+
+fn safe_rcp(value: f32) -> f32 {
+  if (abs(value) <= PATH_TRACER_EPSILON) {
+    return 0.0;
+  }
+
+  return 1.0 / value;
+}
+
+fn safe_normalize(value: vec3<f32>) -> vec3<f32> {
+  if (dot(value, value) <= PATH_TRACER_EPSILON) {
+    return vec3<f32>(0.0, 1.0, 0.0);
+  }
+
+  return normalize(value);
+}
+
+fn make_default_material() -> PathTracerMaterial {
+  return PathTracerMaterial(
+    vec4<f32>(0.72, 0.74, 0.76, 0.5),
+    vec4<f32>(0.0, 0.0, 0.0, 0.0),
+    vec4<f32>(0.0, 0.0, 0.0, 1.45)
+  );
+}
+
+fn unpack_material(material: PathTracerMaterial) -> MaterialSample {
+  return MaterialSample(
+    material.albedo_roughness.xyz,
+    clamp(material.albedo_roughness.w, 0.02, 1.0),
+    material.emission_metalness.xyz,
+    saturate(material.emission_metalness.w),
+    material.transmittance_ior.xyz,
+    max(material.transmittance_ior.w, 1.0)
+  );
+}
+
+fn hash_u32(value: u32) -> u32 {
+  var x = value + 0x9e3779b9u;
+  x = (x ^ (x >> 16u)) * 0x85ebca6bu;
+  x = (x ^ (x >> 13u)) * 0xc2b2ae35u;
+  return x ^ (x >> 16u);
+}
+
+fn random_f32(state: ptr<function, u32>) -> f32 {
+  let next = hash_u32((*state) ^ 0x68bc21ebu);
+  *state = next;
+  return f32(next) * 2.3283064365386963e-10;
+}
+
+fn sample_unit_disk(state: ptr<function, u32>) -> vec2<f32> {
+  let radius = sqrt(random_f32(state));
+  let angle = 2.0 * PATH_TRACER_PI * random_f32(state);
+  return vec2<f32>(cos(angle), sin(angle)) * radius;
+}
+
+fn sample_unit_sphere(state: ptr<function, u32>) -> vec3<f32> {
+  let z = random_f32(state) * 2.0 - 1.0;
+  let angle = 2.0 * PATH_TRACER_PI * random_f32(state);
+  let radius = sqrt(max(1.0 - z * z, 0.0));
+  return vec3<f32>(radius * cos(angle), radius * sin(angle), z);
+}
+
+fn build_tangent(normal: vec3<f32>) -> vec3<f32> {
+  let basis = select(
+    vec3<f32>(0.0, 1.0, 0.0),
+    vec3<f32>(1.0, 0.0, 0.0),
+    abs(normal.y) > 0.999
+  );
+  return safe_normalize(cross(basis, normal));
+}
+
+fn build_bitangent(normal: vec3<f32>, tangent: vec3<f32>) -> vec3<f32> {
+  return safe_normalize(cross(normal, tangent));
+}
+
+fn sample_cosine_hemisphere(normal: vec3<f32>, state: ptr<function, u32>) -> vec3<f32> {
+  let disk = sample_unit_disk(state);
+  let z = sqrt(max(1.0 - dot(disk, disk), 0.0));
+  let tangent = build_tangent(normal);
+  let bitangent = build_bitangent(normal, tangent);
+  return safe_normalize(tangent * disk.x + bitangent * disk.y + normal * z);
+}
+
+fn fresnel_schlick(cos_theta: f32, f0: vec3<f32>) -> vec3<f32> {
+  let factor = pow(1.0 - saturate(cos_theta), 5.0);
+  return f0 + (vec3<f32>(1.0) - f0) * factor;
+}
+
+fn environment_radiance(
+  direction: vec3<f32>,
+  intensity: f32,
+  mode: u32
+) -> vec3<f32> {
+  let up_factor = saturate(direction.y * 0.5 + 0.5);
+  let horizon_color = vec3<f32>(0.65, 0.74, 0.86);
+  let zenith_color = select(
+    vec3<f32>(0.05, 0.12, 0.24),
+    vec3<f32>(0.11, 0.08, 0.18),
+    mode == 1u
+  );
+  let sunset_color = vec3<f32>(1.1, 0.64, 0.32);
+  let sun_direction = safe_normalize(vec3<f32>(0.35, 0.92, 0.18));
+  let moon_direction = safe_normalize(vec3<f32>(-0.2, 0.98, -0.1));
+  let sun_glow = pow(saturate(dot(direction, sun_direction)), 256.0);
+  let moon_glow = pow(saturate(dot(direction, moon_direction)), 512.0);
+  var sky = horizon_color * (1.0 - up_factor) + zenith_color * up_factor;
+  if (mode == 1u) {
+    sky = sky * (1.0 - up_factor * 0.4) + sunset_color * sun_glow * 0.25;
+  }
+  return (
+    sky +
+    vec3<f32>(8.0, 7.6, 6.8) * sun_glow +
+    vec3<f32>(0.7, 0.76, 0.9) * moon_glow * 0.3
+  ) * max(intensity, 0.0001);
+}
+
+fn miss_hit(ray: Ray) -> PathHit {
+  return PathHit(
+    0u,
+    ray.t_max,
+    ray.origin + ray.direction * ray.t_max,
+    0u,
+    vec3<f32>(0.0, 1.0, 0.0),
+    0u,
+    vec3<f32>(0.0),
+    0u
+  );
+}
+
+fn faceforward_normal(normal: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
+  return select(normal, -normal, dot(normal, direction) > 0.0);
 }

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -7,12 +7,15 @@ import { fileURLToPath } from "node:url";
 const originalImportMetaUrl = globalThis.__IMPORT_META_URL__;
 globalThis.__IMPORT_META_URL__ = new URL("../src/index.js", import.meta.url);
 const {
+  createLightingProfileModeLadder,
+  defaultAdaptiveLightingProfilePolicy,
   defaultLightingProfile,
   defaultLightingTechnique,
   getLightingProfile,
   getLightingProfileWorkerManifest,
   getLightingTechnique,
   getLightingTechniqueWorkerManifest,
+  lightingProfileModeOrder,
   lightingProfileNames,
   lightingProfiles,
   lightingPreludeWgslUrl,
@@ -116,6 +119,84 @@ test("lighting job WGSL defines process_job entry points", () => {
   }
 });
 
+test("pathtracer prelude publishes concrete scene, history, and environment contracts", () => {
+  const source = fs.readFileSync(
+    path.resolve(
+      __dirname,
+      "..",
+      "src",
+      "techniques",
+      "pathtracer",
+      "prelude.wgsl"
+    ),
+    "utf8"
+  );
+
+  assert.match(source, /struct PathTracerCamera/);
+  assert.match(source, /struct PathTracerSceneMetadata/);
+  assert.match(source, /struct PathAccumulationPixel/);
+  assert.match(source, /fn environment_radiance/);
+});
+
+test("reference pathtracer WGSL stages are real kernels rather than placeholders", () => {
+  const base = path.resolve(
+    __dirname,
+    "..",
+    "src",
+    "techniques",
+    "pathtracer"
+  );
+  const pathTrace = fs.readFileSync(path.join(base, "pathtrace.job.wgsl"), "utf8");
+  const accumulate = fs.readFileSync(path.join(base, "accumulate.job.wgsl"), "utf8");
+  const denoise = fs.readFileSync(path.join(base, "denoise.job.wgsl"), "utf8");
+
+  assert.match(pathTrace, /@compute\s+@workgroup_size/);
+  assert.match(pathTrace, /fn trace_scene\b/);
+  assert.match(pathTrace, /samples_per_pixel/);
+  assert.match(pathTrace, /max_bounces/);
+  assert.doesNotMatch(pathTrace, /Placeholder/);
+
+  assert.match(accumulate, /PathAccumulationPixel/);
+  assert.match(accumulate, /history_blend/);
+  assert.doesNotMatch(accumulate, /Placeholder/);
+
+  assert.match(denoise, /fn bilateral_weight\b/);
+  assert.match(denoise, /filtered_radiance/);
+  assert.doesNotMatch(denoise, /Placeholder/);
+});
+
+test("hybrid reflection resolve WGSL traces and shapes reflections by surface response", () => {
+  const prelude = fs.readFileSync(
+    path.resolve(
+      __dirname,
+      "..",
+      "src",
+      "techniques",
+      "hybrid",
+      "prelude.wgsl"
+    ),
+    "utf8"
+  );
+  const resolve = fs.readFileSync(
+    path.resolve(
+      __dirname,
+      "..",
+      "src",
+      "techniques",
+      "hybrid",
+      "reflection-resolve.job.wgsl"
+    ),
+    "utf8"
+  );
+
+  assert.match(prelude, /struct HybridReflectionSurface/);
+  assert.match(prelude, /struct HybridReflectionPixel/);
+  assert.match(resolve, /fn trace_reflection_scene\b/);
+  assert.match(resolve, /reflect\(/);
+  assert.match(resolve, /HybridReflectionPixel/);
+  assert.doesNotMatch(resolve, /Placeholder/);
+});
+
 test("lighting profiles reference known techniques", () => {
   assert.ok(lightingProfileNames.length > 0);
   for (const profileName of lightingProfileNames) {
@@ -128,6 +209,63 @@ test("lighting profiles reference known techniques", () => {
       );
     }
   }
+});
+
+test("adaptive lighting profile defaults keep reference mode eligible at a 30 FPS four-frame floor", () => {
+  assert.deepEqual(lightingProfileModeOrder, [
+    "realtime",
+    "hybrid",
+    "reference",
+  ]);
+  assert.deepEqual(defaultAdaptiveLightingProfilePolicy, {
+    preferredProfile: "reference",
+    minimumFrameRate: 30,
+    sampleWindowSize: 4,
+  });
+
+  const ladder = createLightingProfileModeLadder();
+
+  assert.equal(ladder.id, "lighting-profile-mode");
+  assert.equal(ladder.domain, "lighting");
+  assert.equal(ladder.authority, "visual");
+  assert.equal(ladder.importance, "critical");
+  assert.equal(ladder.initialLevel, "reference");
+  assert.deepEqual(
+    ladder.levels.map((level) => level.id),
+    lightingProfileModeOrder
+  );
+  assert.equal(ladder.target.minimumFrameRate, 30);
+  assert.equal(ladder.target.maximumFrameRate, 30);
+  assert.deepEqual(ladder.target.preferredFrameRates, [30]);
+  assert.equal(ladder.adaptation.sampleWindowSize, 4);
+  assert.equal(ladder.adaptation.minimumSamplesBeforeAdjustment, 4);
+  assert.equal(ladder.policy.preferredProfile, "reference");
+
+  const referenceLevel = ladder.levels.find((level) => level.id === "reference");
+  assert.ok(referenceLevel);
+  assert.equal(referenceLevel.config.profile, "reference");
+  assert.ok(referenceLevel.config.techniques.includes("pathtracer"));
+  assert.equal(referenceLevel.config.lightingBandPlan.profile, "reference");
+});
+
+test("adaptive lighting profile ladder supports custom governor window and initial profile overrides", () => {
+  const ladder = createLightingProfileModeLadder({
+    id: "game-lighting-profile-mode",
+    initialProfile: "hybrid",
+    preferredProfile: "reference",
+    minimumFrameRate: 36,
+    sampleWindowSize: 6,
+    importance: "critical",
+    moduleImportance: "high",
+  });
+
+  assert.equal(ladder.id, "game-lighting-profile-mode");
+  assert.equal(ladder.initialLevel, "hybrid");
+  assert.equal(ladder.importance, "high");
+  assert.equal(ladder.target.minimumFrameRate, 36);
+  assert.equal(ladder.adaptation.sampleWindowSize, 6);
+  assert.equal(ladder.policy.sampleWindowSize, 6);
+  assert.equal(ladder.levels[2].config.lightingBandPlan.importance, "critical");
 });
 
 test("loading default profile returns loaded technique bundles", async () => {


### PR DESCRIPTION
## Summary
- replace placeholder pathtracer and hybrid reflection WGSL jobs with concrete kernels
- add regression coverage so placeholder shader stubs cannot slip back in
- document the reference-first adaptive lighting ladder contract and kernel integration boundary

## Validation
- `PATH="/private/tmp/node24/bin:$PATH" npm run typecheck`
- `PATH="/private/tmp/node24/bin:$PATH" npm run audit:eslint`
- `PATH="/private/tmp/node24/bin:$PATH" npm run test:coverage`
- `PATH="/private/tmp/node24/bin:$PATH" npm run build`

Refs Plasius-LTD/plasius-ltd-site#343
Refs Plasius-LTD/plasius-ltd-site#345
Refs #16
Refs #17
Refs #18