### PR TITLE
feat: implement hybrid realtime lighting kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Concrete hybrid realtime WGSL kernels for `directLighting`,
+    `screenTrace`, `radianceCache`, and `finalGather`.
 
 - **Changed**
-  - (placeholder)
+  - README now documents the delivered hybrid realtime kernel scope alongside
+    the existing pathtracer and reflection-resolve stages.
 
 - **Fixed**
-  - (placeholder)
+  - Hybrid realtime technique exports no longer ship placeholder WGSL bodies
+    for the direct-lighting, screen-trace, radiance-cache, and final-gather
+    stages.
 
 - **Security**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ reference-first mode you described:
 
 The package now ships concrete WGSL contracts for:
 
+- `hybrid.directLighting`: direct sun/sky resolve with roughness-aware specular shaping
+- `hybrid.screenTrace`: first-hit reflection tracing over the shared hybrid scene contracts
+- `hybrid.radianceCache`: irradiance history updates for cache-backed indirect reuse
+- `hybrid.finalGather`: cache + trace composition with temporal reuse for the hybrid GI path
 - `pathtracer.pathTrace`: analytic scene tracing, bounce integration, and sky fallback
 - `pathtracer.accumulate`: progressive history resolve with reset handling
 - `pathtracer.denoise`: spatial-temporal bilateral filtering for reference previews

--- a/src/techniques/hybrid/direct-lighting.job.wgsl
+++ b/src/techniques/hybrid/direct-lighting.job.wgsl
@@ -1,3 +1,70 @@
-fn process_job() {
-  // Placeholder direct lighting resolve for the hybrid technique.
+@group(0) @binding(0) var<uniform> hybridFrameParams: HybridFrameParams;
+@group(0) @binding(1) var<uniform> hybridReflectionCamera: HybridReflectionCamera;
+@group(0) @binding(2) var<storage, read> hybridReflectionSurfaces: array<HybridReflectionSurface>;
+@group(0) @binding(3) var<storage, read_write> hybridDirectLightingOutput: array<HybridLightingPixel>;
+
+fn direct_lighting_index(pixel: vec2<u32>) -> u32 {
+  return pixel.y * max(hybridFrameParams.image_width, 1u) + pixel.x;
+}
+
+fn evaluate_direct_sun(
+  normal: vec3<f32>,
+  view_direction: vec3<f32>,
+  albedo: vec3<f32>,
+  roughness: f32,
+  metalness: f32
+) -> vec3<f32> {
+  let sun_direction = hybrid_safe_normalize(vec3<f32>(0.31, 0.92, 0.22));
+  let ndotl = hybrid_saturate(dot(normal, sun_direction));
+  if (ndotl <= 0.0) {
+    return vec3<f32>(0.0);
+  }
+
+  let halfway = hybrid_safe_normalize(sun_direction + view_direction);
+  let f0 = hybrid_surface_f0(albedo, metalness);
+  let fresnel = hybrid_fresnel_schlick(
+    hybrid_saturate(dot(normal, view_direction)),
+    f0
+  );
+  let diffuse = albedo * ndotl * 0.3183098861837907 * (1.0 - metalness);
+  let specular_power = 10.0 + (1.0 - roughness) * 112.0;
+  let specular = fresnel * pow(hybrid_saturate(dot(normal, halfway)), specular_power) * ndotl;
+  let sun_color = vec3<f32>(6.2, 5.8, 5.1) * max(hybridFrameParams.sky_intensity, 0.0001);
+  return (diffuse + specular) * sun_color;
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn process_job(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  if (
+    global_id.x >= hybridFrameParams.image_width ||
+    global_id.y >= hybridFrameParams.image_height
+  ) {
+    return;
+  }
+
+  let index = direct_lighting_index(global_id.xy);
+  let surface = hybridReflectionSurfaces[index];
+  let position = surface.position.xyz;
+  let normal = hybrid_safe_normalize(surface.normal_roughness.xyz);
+  let roughness = clamp(surface.normal_roughness.w + hybridFrameParams.roughness_bias, 0.02, 1.0);
+  let albedo = surface.albedo_metalness.xyz;
+  let metalness = hybrid_saturate(surface.albedo_metalness.w);
+  let emission = surface.emission_occlusion.xyz;
+  let occlusion = hybrid_saturate(surface.emission_occlusion.w);
+  let view_direction = hybrid_safe_normalize(hybridReflectionCamera.position - position);
+  let direct_sun = evaluate_direct_sun(normal, view_direction, albedo, roughness, metalness);
+  let sky_fill = hybrid_environment(normal, hybridFrameParams.sky_intensity, hybridFrameParams.sky_mode);
+  let grazing = pow(1.0 - hybrid_saturate(dot(normal, view_direction)), 4.0);
+  let ambient = sky_fill * (0.08 + grazing * 0.06) * occlusion;
+  let radiance = emission + direct_sun * occlusion + ambient;
+  let confidence = clamp(
+    hybrid_luminance(radiance) * 0.045 + occlusion * 0.35 + (1.0 - roughness) * 0.15,
+    0.0,
+    1.0
+  );
+
+  hybridDirectLightingOutput[index] = HybridLightingPixel(
+    vec4<f32>(radiance * hybridFrameParams.exposure, confidence),
+    vec4<f32>(normal, occlusion)
+  );
 }

--- a/src/techniques/hybrid/final-gather.job.wgsl
+++ b/src/techniques/hybrid/final-gather.job.wgsl
@@ -1,3 +1,63 @@
-fn process_job() {
-  // Placeholder final gather stage that combines cache data and traces.
+@group(0) @binding(0) var<uniform> hybridFrameParams: HybridFrameParams;
+@group(0) @binding(1) var<storage, read> hybridReflectionSurfaces: array<HybridReflectionSurface>;
+@group(0) @binding(2) var<storage, read> hybridDirectLightingInput: array<HybridLightingPixel>;
+@group(0) @binding(3) var<storage, read> hybridScreenTraceInput: array<HybridScreenTracePixel>;
+@group(0) @binding(4) var<storage, read> hybridRadianceCacheInput: array<HybridRadianceCacheEntry>;
+@group(0) @binding(5) var<storage, read_write> hybridFinalGatherOutput: array<HybridLightingPixel>;
+
+fn final_gather_index(pixel: vec2<u32>) -> u32 {
+  return pixel.y * max(hybridFrameParams.image_width, 1u) + pixel.x;
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn process_job(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  if (
+    global_id.x >= hybridFrameParams.image_width ||
+    global_id.y >= hybridFrameParams.image_height
+  ) {
+    return;
+  }
+
+  let index = final_gather_index(global_id.xy);
+  let surface = hybridReflectionSurfaces[index];
+  let direct = hybridDirectLightingInput[index];
+  let trace = hybridScreenTraceInput[index];
+  let cache = hybridRadianceCacheInput[index];
+  let previous = hybridFinalGatherOutput[index];
+  let normal = hybrid_safe_normalize(surface.normal_roughness.xyz);
+  let roughness = clamp(surface.normal_roughness.w + hybridFrameParams.roughness_bias, 0.02, 1.0);
+  let metalness = hybrid_saturate(surface.albedo_metalness.w);
+  let emission = surface.emission_occlusion.xyz;
+  let occlusion = hybrid_saturate(surface.emission_occlusion.w);
+  let direct_radiance = direct.radiance_confidence.xyz;
+  let trace_radiance = trace.radiance_confidence.xyz;
+  let cache_irradiance = cache.irradiance_validity.xyz;
+  let indirect_gi =
+    cache_irradiance * occlusion * (0.32 + (1.0 - roughness) * 0.28);
+  let reflection_term =
+    trace_radiance *
+    trace.radiance_confidence.w *
+    (0.18 + (1.0 - roughness) * 0.42 + metalness * 0.25);
+  let ambient = hybrid_environment(normal, hybridFrameParams.sky_intensity, hybridFrameParams.sky_mode) * 0.05 * occlusion;
+  let current_radiance = direct_radiance + indirect_gi + reflection_term + emission + ambient;
+  let history_weight = select(
+    0.0,
+    encode_history_weight(hybridFrameParams.history_weight),
+    hybridFrameParams.reflection_reset == 0u && previous.radiance_confidence.w > 0.0
+  );
+  let resolved_radiance =
+    previous.radiance_confidence.xyz * history_weight +
+    current_radiance * (1.0 - history_weight);
+  let confidence = clamp(
+    direct.radiance_confidence.w * 0.4 +
+    cache.irradiance_validity.w * 0.3 +
+    trace.radiance_confidence.w * 0.3,
+    0.0,
+    1.0
+  );
+
+  hybridFinalGatherOutput[index] = HybridLightingPixel(
+    vec4<f32>(resolved_radiance, confidence),
+    vec4<f32>(normal, occlusion)
+  );
 }

--- a/src/techniques/hybrid/prelude.wgsl
+++ b/src/techniques/hybrid/prelude.wgsl
@@ -71,6 +71,21 @@ struct HybridReflectionPixel {
   hit_normal_distance: vec4<f32>,
 };
 
+struct HybridLightingPixel {
+  radiance_confidence: vec4<f32>,
+  normal_occlusion: vec4<f32>,
+};
+
+struct HybridScreenTracePixel {
+  radiance_confidence: vec4<f32>,
+  hit_normal_distance: vec4<f32>,
+};
+
+struct HybridRadianceCacheEntry {
+  irradiance_validity: vec4<f32>,
+  bent_normal_depth: vec4<f32>,
+};
+
 fn encode_history_weight(value: f32) -> f32 {
   return clamp(value, 0.0, 1.0);
 }
@@ -90,6 +105,14 @@ fn hybrid_safe_normalize(value: vec3<f32>) -> vec3<f32> {
 fn hybrid_fresnel_schlick(cos_theta: f32, f0: vec3<f32>) -> vec3<f32> {
   let factor = pow(1.0 - hybrid_saturate(cos_theta), 5.0);
   return f0 + (vec3<f32>(1.0) - f0) * factor;
+}
+
+fn hybrid_surface_f0(albedo: vec3<f32>, metalness: f32) -> vec3<f32> {
+  return vec3<f32>(0.04) * (1.0 - metalness) + albedo * metalness;
+}
+
+fn hybrid_luminance(color: vec3<f32>) -> f32 {
+  return dot(color, vec3<f32>(0.2126, 0.7152, 0.0722));
 }
 
 fn hybrid_hash_u32(value: u32) -> u32 {

--- a/src/techniques/hybrid/radiance-cache.job.wgsl
+++ b/src/techniques/hybrid/radiance-cache.job.wgsl
@@ -1,3 +1,58 @@
-fn process_job() {
-  // Placeholder radiance cache update stage for indirect lighting reuse.
+@group(0) @binding(0) var<uniform> hybridFrameParams: HybridFrameParams;
+@group(0) @binding(1) var<storage, read> hybridReflectionSurfaces: array<HybridReflectionSurface>;
+@group(0) @binding(2) var<storage, read> hybridDirectLightingInput: array<HybridLightingPixel>;
+@group(0) @binding(3) var<storage, read> hybridRadianceCacheHistory: array<HybridRadianceCacheEntry>;
+@group(0) @binding(4) var<storage, read_write> hybridRadianceCacheOutput: array<HybridRadianceCacheEntry>;
+
+fn radiance_cache_index(pixel: vec2<u32>) -> u32 {
+  return pixel.y * max(hybridFrameParams.image_width, 1u) + pixel.x;
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn process_job(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  if (
+    global_id.x >= hybridFrameParams.image_width ||
+    global_id.y >= hybridFrameParams.image_height
+  ) {
+    return;
+  }
+
+  let index = radiance_cache_index(global_id.xy);
+  let surface = hybridReflectionSurfaces[index];
+  let direct = hybridDirectLightingInput[index];
+  let previous = hybridRadianceCacheHistory[index];
+  let normal = hybrid_safe_normalize(surface.normal_roughness.xyz);
+  let roughness = clamp(surface.normal_roughness.w + hybridFrameParams.roughness_bias, 0.02, 1.0);
+  let occlusion = hybrid_saturate(surface.emission_occlusion.w);
+  let sky_probe = hybrid_environment(normal, hybridFrameParams.sky_intensity, hybridFrameParams.sky_mode);
+  let direct_irradiance = direct.radiance_confidence.xyz * (0.28 + (1.0 - roughness) * 0.12);
+  let cache_fill = sky_probe * (0.08 + occlusion * 0.12);
+  let current_irradiance = direct_irradiance + cache_fill;
+  let bent_normal = hybrid_safe_normalize(
+    normal * (0.75 + occlusion * 0.25) +
+    previous.bent_normal_depth.xyz * previous.irradiance_validity.w * 0.2
+  );
+  let history_weight = select(
+    0.0,
+    encode_history_weight(hybridFrameParams.history_weight) * previous.irradiance_validity.w,
+    hybridFrameParams.reflection_reset == 0u && previous.irradiance_validity.w > 0.0
+  );
+  let resolved_irradiance =
+    previous.irradiance_validity.xyz * history_weight +
+    current_irradiance * (1.0 - history_weight);
+  let validity = clamp(
+    hybrid_luminance(resolved_irradiance) * 0.05 +
+    occlusion * 0.35 +
+    (1.0 - roughness) * 0.15,
+    0.0,
+    1.0
+  );
+  let probe_depth =
+    previous.bent_normal_depth.w * history_weight +
+    length(surface.position.xyz) * (1.0 - history_weight);
+
+  hybridRadianceCacheOutput[index] = HybridRadianceCacheEntry(
+    vec4<f32>(resolved_irradiance, validity),
+    vec4<f32>(bent_normal, probe_depth)
+  );
 }

--- a/src/techniques/hybrid/screen-trace.job.wgsl
+++ b/src/techniques/hybrid/screen-trace.job.wgsl
@@ -1,3 +1,220 @@
-fn process_job() {
-  // Placeholder screen-space tracing stage for first-hit reuse.
+@group(0) @binding(0) var<uniform> hybridFrameParams: HybridFrameParams;
+@group(0) @binding(1) var<uniform> hybridReflectionCamera: HybridReflectionCamera;
+@group(0) @binding(2) var<storage, read> hybridReflectionSurfaces: array<HybridReflectionSurface>;
+@group(0) @binding(3) var<storage, read> hybridScreenTraceHistory: array<HybridScreenTracePixel>;
+@group(0) @binding(4) var<storage, read> hybridReflectionScene: HybridReflectionSceneMetadata;
+@group(0) @binding(5) var<uniform> hybridGroundPlane: HybridGroundPlane;
+@group(0) @binding(6) var<storage, read> hybridReflectionMaterials: array<HybridReflectionMaterial>;
+@group(0) @binding(7) var<storage, read> hybridReflectionSpheres: array<HybridReflectionSphere>;
+@group(0) @binding(8) var<storage, read_write> hybridScreenTraceOutput: array<HybridScreenTracePixel>;
+
+fn screen_trace_index(pixel: vec2<u32>) -> u32 {
+  return pixel.y * max(hybridFrameParams.image_width, 1u) + pixel.x;
+}
+
+fn unpack_reflection_material(index: u32) -> HybridReflectionMaterial {
+  if (hybridReflectionScene.material_count == 0u) {
+    return HybridReflectionMaterial(
+      vec4<f32>(0.7, 0.72, 0.76, 0.4),
+      vec4<f32>(0.0, 0.0, 0.0, 0.0)
+    );
+  }
+
+  let safe_index = min(index, hybridReflectionScene.material_count - 1u);
+  return hybridReflectionMaterials[safe_index];
+}
+
+fn miss_trace() -> HybridReflectionTrace {
+  return HybridReflectionTrace(
+    0u,
+    hybridReflectionScene.max_trace_distance,
+    vec3<f32>(0.0),
+    0u,
+    vec3<f32>(0.0, 1.0, 0.0),
+    0u
+  );
+}
+
+fn set_best_trace(best: ptr<function, HybridReflectionTrace>, candidate: HybridReflectionTrace) {
+  if (candidate.hit_mask == 1u && candidate.distance < (*best).distance) {
+    *best = candidate;
+  }
+}
+
+fn trace_ground(
+  origin: vec3<f32>,
+  direction: vec3<f32>,
+  best: ptr<function, HybridReflectionTrace>
+) {
+  if (hybridGroundPlane.enabled == 0u) {
+    return;
+  }
+
+  let plane_normal = hybrid_safe_normalize(hybridGroundPlane.normal);
+  let denominator = dot(plane_normal, direction);
+  if (abs(denominator) <= 0.0005) {
+    return;
+  }
+
+  let distance = -(dot(plane_normal, origin) + hybridGroundPlane.height) / denominator;
+  if (distance <= 0.0005 || distance >= (*best).distance || distance >= hybridReflectionScene.max_trace_distance) {
+    return;
+  }
+
+  set_best_trace(
+    best,
+    HybridReflectionTrace(
+      1u,
+      distance,
+      origin + direction * distance,
+      hybridGroundPlane.material_index,
+      plane_normal,
+      0u
+    )
+  );
+}
+
+fn trace_spheres(
+  origin: vec3<f32>,
+  direction: vec3<f32>,
+  best: ptr<function, HybridReflectionTrace>
+) {
+  var index = 0u;
+  loop {
+    if (index >= hybridReflectionScene.sphere_count) {
+      break;
+    }
+
+    let sphere = hybridReflectionSpheres[index];
+    let offset = origin - sphere.center_radius.xyz;
+    let a = dot(direction, direction);
+    let half_b = dot(offset, direction);
+    let c = dot(offset, offset) - sphere.center_radius.w * sphere.center_radius.w;
+    let discriminant = half_b * half_b - a * c;
+    if (discriminant >= 0.0) {
+      let root = sqrt(discriminant);
+      var distance = (-half_b - root) / max(a, 0.0005);
+      if (distance <= 0.0005) {
+        distance = (-half_b + root) / max(a, 0.0005);
+      }
+      if (distance > 0.0005 && distance < (*best).distance && distance < hybridReflectionScene.max_trace_distance) {
+        let position = origin + direction * distance;
+        let normal = hybrid_safe_normalize(position - sphere.center_radius.xyz);
+        set_best_trace(
+          best,
+          HybridReflectionTrace(
+            1u,
+            distance,
+            position,
+            sphere.material_index,
+            normal,
+            0u
+          )
+        );
+      }
+    }
+
+    index = index + 1u;
+  }
+}
+
+fn trace_screen_scene(origin: vec3<f32>, direction: vec3<f32>) -> HybridReflectionTrace {
+  var best = miss_trace();
+  trace_ground(origin, direction, &best);
+  trace_spheres(origin, direction, &best);
+  return best;
+}
+
+fn evaluate_hit_radiance(trace: HybridReflectionTrace, reflection_direction: vec3<f32>) -> vec3<f32> {
+  let material = unpack_reflection_material(trace.material_index);
+  let normal = hybrid_safe_normalize(trace.normal);
+  let view_direction = -reflection_direction;
+  let light_direction = hybrid_safe_normalize(vec3<f32>(0.31, 0.92, 0.22));
+  let ndotl = hybrid_saturate(dot(normal, light_direction));
+  let halfway = hybrid_safe_normalize(light_direction + view_direction);
+  let roughness = clamp(material.albedo_roughness.w, 0.02, 1.0);
+  let metalness = hybrid_saturate(material.emission_metalness.w);
+  let albedo = material.albedo_roughness.xyz;
+  let fresnel = hybrid_fresnel_schlick(
+    hybrid_saturate(dot(normal, view_direction)),
+    hybrid_surface_f0(albedo, metalness)
+  );
+  let diffuse = albedo * ndotl * 0.3183098861837907 * (1.0 - metalness);
+  let specular = fresnel * pow(hybrid_saturate(dot(normal, halfway)), 12.0 + (1.0 - roughness) * 84.0) * ndotl;
+  let sky_fill = hybrid_environment(normal, hybridFrameParams.sky_intensity, hybridFrameParams.sky_mode);
+  return material.emission_metalness.xyz + (diffuse + specular) * vec3<f32>(4.8, 4.5, 4.1) + sky_fill * 0.1;
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn process_job(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  if (
+    global_id.x >= hybridFrameParams.image_width ||
+    global_id.y >= hybridFrameParams.image_height
+  ) {
+    return;
+  }
+
+  let index = screen_trace_index(global_id.xy);
+  let surface = hybridReflectionSurfaces[index];
+  let previous = hybridScreenTraceHistory[index];
+  let position = surface.position.xyz;
+  let normal = hybrid_safe_normalize(surface.normal_roughness.xyz);
+  let roughness = clamp(surface.normal_roughness.w + hybridFrameParams.roughness_bias, 0.02, 1.0);
+  let albedo = surface.albedo_metalness.xyz;
+  let metalness = hybrid_saturate(surface.albedo_metalness.w);
+  let occlusion = hybrid_saturate(surface.emission_occlusion.w);
+  let view_direction = hybrid_safe_normalize(hybridReflectionCamera.position - position);
+  var random_state = hybrid_hash_u32(
+    hybridFrameParams.frame_index * 1664525u +
+    index * 1013904223u +
+    0x68bc21ebu
+  );
+  let reflected_direction = hybrid_safe_normalize(
+    reflect(-view_direction, normal) +
+    hybrid_sample_unit_sphere(&random_state) * roughness * roughness * 0.25
+  );
+  let trace = trace_screen_scene(
+    position + normal * max(hybridFrameParams.thickness, 0.0005),
+    reflected_direction
+  );
+  let sky_fallback = hybrid_environment(
+    reflected_direction,
+    hybridFrameParams.sky_intensity,
+    hybridFrameParams.sky_mode
+  );
+  let hit_radiance = select(
+    sky_fallback,
+    evaluate_hit_radiance(trace, reflected_direction),
+    trace.hit_mask == 1u
+  );
+  let reflection_budget = clamp(
+    max(hybrid_surface_f0(albedo, metalness).x, max(albedo.y * metalness, albedo.z * metalness)) +
+      (1.0 - roughness) * 0.45,
+    0.0,
+    1.0
+  );
+  let trace_confidence = clamp(
+    reflection_budget * occlusion * select(0.35, 0.9, trace.hit_mask == 1u),
+    0.0,
+    1.0
+  );
+  let history_weight = select(
+    0.0,
+    encode_history_weight(hybridFrameParams.history_weight),
+    hybridFrameParams.reflection_reset == 0u && previous.radiance_confidence.w > 0.0
+  );
+  let resolved_radiance =
+    previous.radiance_confidence.xyz * history_weight +
+    hit_radiance * trace_confidence * (1.0 - history_weight);
+  let resolved_normal = select(normal, hybrid_safe_normalize(trace.normal), trace.hit_mask == 1u);
+  let resolved_distance = select(
+    hybridFrameParams.max_reflection_distance,
+    trace.distance,
+    trace.hit_mask == 1u
+  );
+
+  hybridScreenTraceOutput[index] = HybridScreenTracePixel(
+    vec4<f32>(resolved_radiance * hybridFrameParams.exposure, trace_confidence),
+    vec4<f32>(resolved_normal, resolved_distance)
+  );
 }

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -197,6 +197,52 @@ test("hybrid reflection resolve WGSL traces and shapes reflections by surface re
   assert.doesNotMatch(resolve, /Placeholder/);
 });
 
+test("hybrid realtime WGSL stages are real kernels rather than placeholders", () => {
+  const base = path.resolve(
+    __dirname,
+    "..",
+    "src",
+    "techniques",
+    "hybrid"
+  );
+  const directLighting = fs.readFileSync(
+    path.join(base, "direct-lighting.job.wgsl"),
+    "utf8"
+  );
+  const screenTrace = fs.readFileSync(
+    path.join(base, "screen-trace.job.wgsl"),
+    "utf8"
+  );
+  const radianceCache = fs.readFileSync(
+    path.join(base, "radiance-cache.job.wgsl"),
+    "utf8"
+  );
+  const finalGather = fs.readFileSync(
+    path.join(base, "final-gather.job.wgsl"),
+    "utf8"
+  );
+
+  assert.match(directLighting, /HybridLightingPixel/);
+  assert.match(directLighting, /evaluate_direct_sun/);
+  assert.match(directLighting, /@compute\s+@workgroup_size/);
+  assert.doesNotMatch(directLighting, /Placeholder/);
+
+  assert.match(screenTrace, /trace_screen_scene/);
+  assert.match(screenTrace, /HybridScreenTracePixel/);
+  assert.match(screenTrace, /HybridReflectionTrace/);
+  assert.doesNotMatch(screenTrace, /Placeholder/);
+
+  assert.match(radianceCache, /HybridRadianceCacheEntry/);
+  assert.match(radianceCache, /resolved_irradiance/);
+  assert.match(radianceCache, /history_weight/);
+  assert.doesNotMatch(radianceCache, /Placeholder/);
+
+  assert.match(finalGather, /HybridLightingPixel/);
+  assert.match(finalGather, /indirect_gi/);
+  assert.match(finalGather, /reflection_term/);
+  assert.doesNotMatch(finalGather, /Placeholder/);
+});
+
 test("lighting profiles reference known techniques", () => {
   assert.ok(lightingProfileNames.length > 0);
   for (const profileName of lightingProfileNames) {


### PR DESCRIPTION
## Summary
- replace the four placeholder hybrid WGSL stages with concrete direct-lighting, screen-trace, radiance-cache, and final-gather kernels
- extend the hybrid prelude with shared pixel/cache structs and helper math used by the new passes
- add targeted package regression coverage and update README/changelog for the delivered hybrid scope

## Validation
- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run test:coverage`
- `npm run pack:check`
- `npm run lint`
- `npm_config_cache=/Users/philliphounslow/plasius/gpu-lighting-task22/.npm-cache npm pack --dry-run`
