### PR TITLE
Expand environment lighting presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,19 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added environment-light portal contracts to the reusable environment
+    lighting config so renderers can guide and gate sky/HDRI contribution
+    through room openings such as windows.
+  - Added grass-field, forest, warehouse, and cavern environment lighting
+    preset families with dawn, midday, dusk, and night variants plus normalized
+    light-source metadata for environment-miss inference.
+  - Added scene/time-of-day preset aliases so callers can request environments
+    with `scene` plus `timeOfDay` instead of only combined preset names.
 
 - **Changed**
-  - (placeholder)
+  - Pathtracer environment misses now resolve through non-null inferred
+    environment radiance, and emissive material hits contribute once before
+    terminating the active sample path.
 
 - **Fixed**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -114,18 +114,58 @@ import {
 } from "@plasius/gpu-lighting";
 
 const lighting = createEnvironmentLightingConfig({
-  preset: "product-studio",
+  scene: "forest",
+  timeOfDay: "dusk",
   intensity: 1.05,
+  environmentPortals: [
+    {
+      id: "north-window",
+      position: [0, 1.2, -2.4],
+      normal: [0, 0, 1],
+      tangent: [1, 0, 0],
+      width: 1.8,
+      height: 1.1,
+      intensity: 1.4,
+    },
+  ],
 });
 
 const wavefrontLighting = createWavefrontEnvironmentLightingOptions({
-  preset: "moonlit-harbor",
+  preset: "cavern-night",
 });
+
+console.log(lighting.environmentLightSources.map((source) => source.kind));
+console.log(wavefrontLighting.environmentMissLighting.startingPoint);
 ```
 
 `createEnvironmentLightingConfig(...)` owns the reusable sky/environment
 semantics: horizon and zenith colours, key-light direction, key-light colour,
-environment intensity, exposure, and ambient residual colour.
+environment intensity, exposure, ambient residual colour, and optional
+environment-light portals.
+
+Preset families now cover:
+
+- `grass-field-{dawn,midday,dusk,night}`
+- `forest-{dawn,midday,dusk,night}`
+- `warehouse-{dawn,midday,dusk,night}`
+- `cavern-{dawn,midday,dusk,night}`
+
+Callers can pass the combined `preset` name directly or pass `scene` plus
+`timeOfDay`; scene-only aliases default to `midday`.
+
+Each preset publishes `scene`, `timeOfDay`, normalized
+`environmentLightSources`, a `dominantLightSource`, and
+`environmentMissLighting`. Source metadata includes source kind, role, direction,
+position, colour, intensity, radiance, luminance, reach, and angular radius.
+Renderers can use `environmentMissLighting` when a path ray misses scene
+geometry: the miss has an inferred source colour/brightness and a stable
+`startingPoint` of `environment-miss` instead of an unbounded null/negative sky
+sample. Emissive material hits remain explicit light-source hits and should not
+be double-counted by environment inference.
+
+Portals describe physical openings such as windows where outside radiance can
+enter an interior. They are normalized as rectangle apertures with position,
+normal, tangent, dimensions, colour, and radiance scale.
 `createWavefrontEnvironmentLightingOptions(...)` projects that contract into the
 current `@plasius/gpu-renderer` wavefront renderer options without making the
 renderer depend on this package directly.

--- a/docs/adrs/adr-0004: HDRI-First Physical Lighting and Exposure.md
+++ b/docs/adrs/adr-0004: HDRI-First Physical Lighting and Exposure.md
@@ -42,6 +42,29 @@ Adopt an HDRI-first pipeline (`hdri` technique) that includes:
 Pair this with physical exposure assumptions and ACES-compatible tone-mapping
 at integration points in consuming runtimes.
 
+Environment lighting configs also publish optional rectangular environment-light
+portals. A portal represents a physical opening, such as a window or door, where
+outside sky/HDRI radiance is available to an interior path tracer. The lighting
+package owns the reusable semantics and normalization of these apertures,
+including position, normal, tangent, dimensions, colour, radiance scale, and
+guide/gate mode. Consuming renderers remain responsible for GPU upload,
+visibility tests, ray continuation policy, and final integration.
+
+Environment presets also publish scene/time-of-day metadata and normalized
+light-source descriptors. Outdoor, interior, and underground preset families
+(`grass-field`, `forest`, `warehouse`, and `cavern`) each expose dawn, midday,
+dusk, and night variants. Each variant declares source kinds such as sun, moon,
+sky, canopy transmission, fluorescent strips, cave mouth, torch, bioluminescent
+fill, or lava fissures.
+
+When a path ray misses scene geometry, renderers should treat the environment
+sample as inferred light from the preset's dominant source metadata. The
+contract must provide non-negative colour, radiance, luminance, direction, and a
+stable `environment-miss` starting point so render validation never has to
+interpret a null or negative colour space. Explicit emissive material hits
+remain physical light-source hits and should terminate active sample paths
+before environment inference is applied.
+
 ---
 
 ## Alternatives Considered
@@ -51,14 +74,25 @@ at integration points in consuming runtimes.
 - **Reflection probes without HDRI precompute**: partial result with weaker
   energy consistency.
 - **Manual artist-only exposure tuning**: inconsistent and hard to automate.
+- **Renderer-local window constants**: quick to prototype but duplicates
+  lighting semantics and prevents product scenes from sharing one environment
+  contract across renderers.
+- **Preset names without light-source metadata**: easier to expose but leaves
+  pathtracers guessing source colour and brightness on environment misses.
 
 ---
 
 ## Consequences
 
 - Improves realism and consistency across lighting profiles.
+- Allows interior renderers to constrain external environment contribution to
+  real openings instead of treating the whole sky as visible from every bounce.
+- Gives renderers deterministic environment-miss radiance metadata for render
+  checks and path-tracing diagnostics.
 - Adds precompute steps and asset preparation requirements.
 - Creates a strong baseline for material validation in the path-traced mode.
+- Adds a small shared data contract that renderers must map to their GPU buffer
+  layouts.
 
 ---
 

--- a/src/index.js
+++ b/src/index.js
@@ -136,10 +136,45 @@ export const lightingProfileModeOrder = Object.freeze([
   "hybrid",
   "reference",
 ]);
-export const lightingEnvironmentPresetNames = Object.freeze([
-  "moonlit-harbor",
-  "product-studio",
-  "neutral-studio",
+export const lightingEnvironmentTimeOfDayNames = Object.freeze([
+  "dawn",
+  "midday",
+  "dusk",
+  "night",
+]);
+export const lightingEnvironmentSceneNames = Object.freeze([
+  "studio",
+  "harbor",
+  "grass-field",
+  "forest",
+  "warehouse",
+  "cavern",
+]);
+export const lightingEnvironmentLightSourceKinds = Object.freeze([
+  "sky",
+  "sun",
+  "moon",
+  "stars",
+  "horizon-glow",
+  "ground-bounce",
+  "studio-softbox",
+  "canopy-transmission",
+  "window-portal",
+  "fluorescent-strip",
+  "sodium-door",
+  "emergency-beacon",
+  "cave-mouth",
+  "torch",
+  "bioluminescence",
+  "lava-fissure",
+  "crystal",
+  "custom",
+]);
+export const lightingEnvironmentPortalShapes = Object.freeze(["rectangle"]);
+export const lightingEnvironmentPortalModes = Object.freeze([
+  "disabled",
+  "guide",
+  "guide-and-gate",
 ]);
 export const defaultAdaptiveLightingProfilePolicy = Object.freeze({
   preferredProfile: "reference",
@@ -188,13 +223,301 @@ function readColor(value, fallback) {
   ]);
 }
 
+function colorLuminance(value) {
+  return value[0] * 0.2126 + value[1] * 0.7152 + value[2] * 0.0722;
+}
+
+function readPositiveColor(value, fallback) {
+  const color = readColor(value, fallback);
+  const fallbackColor = readColor(fallback, [1, 1, 1, 1]);
+  return freezeVec4([
+    color[0] > 0 ? color[0] : Math.max(fallbackColor[0], 0.0001),
+    color[1] > 0 ? color[1] : Math.max(fallbackColor[1], 0.0001),
+    color[2] > 0 ? color[2] : Math.max(fallbackColor[2], 0.0001),
+    color[3],
+  ]);
+}
+
+function ensureNonNullColor(value, fallback = [1, 1, 1, 1]) {
+  const color = readColor(value, fallback);
+  if (colorLuminance(color) > 0.000001) {
+    return color;
+  }
+  return readPositiveColor(fallback, [1, 1, 1, 1]);
+}
+
 function readFinite(value, fallback) {
   return Number.isFinite(value) ? value : fallback;
 }
 
+function readVector3(value, fallback) {
+  if (!Array.isArray(value) || value.length < 3) {
+    return [...fallback];
+  }
+  return [
+    Number.isFinite(value[0]) ? value[0] : fallback[0],
+    Number.isFinite(value[1]) ? value[1] : fallback[1],
+    Number.isFinite(value[2]) ? value[2] : fallback[2],
+  ];
+}
+
+function dot3(a, b) {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+function cross3(a, b) {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+function normalizeRawVector3(value, fallback) {
+  const length = Math.hypot(value[0], value[1], value[2]);
+  if (!Number.isFinite(length) || length <= 0.000001) {
+    return [...fallback];
+  }
+  return value.map((component) => component / length);
+}
+
+function orthogonalFallback(normal) {
+  if (Math.abs(normal[1]) < 0.92) {
+    return normalizeRawVector3(cross3([0, 1, 0], normal), [1, 0, 0]);
+  }
+  return normalizeRawVector3(cross3([1, 0, 0], normal), [0, 0, 1]);
+}
+
+function normalizePortalTangent(value, normal) {
+  const raw = normalizeVector3(value, orthogonalFallback(normal));
+  const projected = [
+    raw[0] - normal[0] * dot3(raw, normal),
+    raw[1] - normal[1] * dot3(raw, normal),
+    raw[2] - normal[2] * dot3(raw, normal),
+  ];
+  return normalizeRawVector3(projected, orthogonalFallback(normal));
+}
+
+function readPositiveFinite(value, fallback) {
+  const number = Number(value ?? fallback);
+  if (!Number.isFinite(number)) {
+    return fallback;
+  }
+  return Math.max(number, 0.0001);
+}
+
+function normalizeEnvironmentPortalMode(value, hasPortals) {
+  if (value == null) {
+    return hasPortals ? "guide-and-gate" : "disabled";
+  }
+  if (value === "gate") {
+    return "guide-and-gate";
+  }
+  if (lightingEnvironmentPortalModes.includes(value)) {
+    return value;
+  }
+  throw new Error(
+    `environmentPortalMode must be one of: ${lightingEnvironmentPortalModes.join(", ")}.`
+  );
+}
+
+function normalizeEnvironmentPortal(portal, index) {
+  if (!portal || typeof portal !== "object") {
+    throw new Error(`environmentPortals[${index}] must be an object.`);
+  }
+  const shape = portal.shape ?? portal.kind ?? "rectangle";
+  if (!lightingEnvironmentPortalShapes.includes(shape)) {
+    throw new Error(
+      `environmentPortals[${index}].shape must be one of: ${lightingEnvironmentPortalShapes.join(", ")}.`
+    );
+  }
+  const normal = Object.freeze(
+    normalizeVector3(portal.normal, [0, 0, 1])
+  );
+  const tangent = Object.freeze(normalizePortalTangent(portal.tangent, normal));
+  const bitangent = Object.freeze(
+    normalizeRawVector3(cross3(normal, tangent), [0, 1, 0])
+  );
+  const width = readPositiveFinite(
+    portal.width,
+    readPositiveFinite(portal.halfWidth, 0.5) * 2
+  );
+  const height = readPositiveFinite(
+    portal.height,
+    readPositiveFinite(portal.halfHeight, 0.5) * 2
+  );
+  const radianceScale = Math.max(
+    0,
+    readFinite(portal.radianceScale ?? portal.intensity, 1)
+  );
+  return Object.freeze({
+    id: typeof portal.id === "string" && portal.id.length > 0
+      ? portal.id
+      : `environment-portal-${index}`,
+    shape,
+    position: Object.freeze(readVector3(portal.position ?? portal.center, [0, 0, 0])),
+    normal,
+    tangent,
+    bitangent,
+    width,
+    height,
+    radianceScale,
+    color: readColor(portal.color, [1, 1, 1, 1]),
+    twoSided: portal.twoSided !== false,
+  });
+}
+
+function normalizeEnvironmentPortals(value) {
+  if (value == null) {
+    return Object.freeze([]);
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("environmentPortals must be an array when provided.");
+  }
+  return Object.freeze(value.map(normalizeEnvironmentPortal));
+}
+
+function freezeLightSourceSpec(source) {
+  return Object.freeze({
+    ...source,
+    color: source.color ? freezeVec4(source.color) : undefined,
+    direction: source.direction
+      ? Object.freeze(normalizeVector3(source.direction, [0, 1, 0]))
+      : undefined,
+    position: source.position
+      ? Object.freeze(readVector3(source.position, [0, 0, 0]))
+      : undefined,
+  });
+}
+
+function defineEnvironmentPreset(spec) {
+  return Object.freeze({
+    ...spec,
+    scene: spec.scene ?? "studio",
+    timeOfDay: spec.timeOfDay ?? "midday",
+    horizonColor: freezeVec4(spec.horizonColor),
+    zenithColor: freezeVec4(spec.zenithColor),
+    sunDirection: Object.freeze(normalizeVector3(spec.sunDirection, [0, 1, 0])),
+    sunColor: freezeVec4(spec.sunColor),
+    ambientColor: freezeVec4(spec.ambientColor),
+    environmentLightSources: Object.freeze(
+      (spec.environmentLightSources ?? []).map(freezeLightSourceSpec)
+    ),
+  });
+}
+
+function buildEnvironmentLightSourceFallback(config, preset) {
+  const firstPresetSource = preset.environmentLightSources[0] ?? {};
+  return {
+    kind: firstPresetSource.kind ?? "sky",
+    role: firstPresetSource.role ?? "fill",
+    color: firstPresetSource.color ?? config.sunColor,
+    intensity:
+      firstPresetSource.intensity ??
+      Math.max(config.environmentIntensity, 0.0001),
+    direction: firstPresetSource.direction ?? config.sunDirection,
+    angularRadiusRadians: firstPresetSource.angularRadiusRadians ?? 0.25,
+    reach: firstPresetSource.reach ?? 1000,
+  };
+}
+
+function normalizeEnvironmentLightSource(source, index, fallback) {
+  if (!source || typeof source !== "object") {
+    throw new Error(`environmentLightSources[${index}] must be an object.`);
+  }
+  const requestedKind = source.kind ?? source.type ?? fallback.kind ?? "custom";
+  const kind = lightingEnvironmentLightSourceKinds.includes(requestedKind)
+    ? requestedKind
+    : "custom";
+  const color = readPositiveColor(source.color, fallback.color ?? [1, 1, 1, 1]);
+  const intensity = readPositiveFinite(
+    source.intensity ?? source.radianceScale,
+    fallback.intensity ?? 1
+  );
+  const radiance = freezeVec4([
+    color[0] * intensity,
+    color[1] * intensity,
+    color[2] * intensity,
+    color[3],
+  ]);
+  return Object.freeze({
+    id:
+      typeof source.id === "string" && source.id.length > 0
+        ? source.id
+        : `environment-light-source-${index}`,
+    kind,
+    type: kind,
+    role:
+      typeof source.role === "string" && source.role.length > 0
+        ? source.role
+        : fallback.role ?? "fill",
+    direction: Object.freeze(
+      normalizeVector3(source.direction, fallback.direction ?? [0, 1, 0])
+    ),
+    position: Object.freeze(
+      readVector3(source.position ?? source.origin, fallback.position ?? [0, 0, 0])
+    ),
+    color,
+    intensity,
+    radiance,
+    luminance: colorLuminance(radiance),
+    angularRadiusRadians: readPositiveFinite(
+      source.angularRadiusRadians ?? source.angularRadius,
+      fallback.angularRadiusRadians ?? 0.25
+    ),
+    reach: readPositiveFinite(
+      source.reach ?? source.distance,
+      fallback.reach ?? 1000
+    ),
+    castsShadows: source.castsShadows !== false,
+    contributesToEnvironment: source.contributesToEnvironment !== false,
+  });
+}
+
+function normalizeEnvironmentLightSources(value, preset, config) {
+  const baseSources = value ?? preset.environmentLightSources;
+  const fallback = buildEnvironmentLightSourceFallback(config, preset);
+  if (!Array.isArray(baseSources)) {
+    throw new Error("environmentLightSources must be an array when provided.");
+  }
+  const normalizedSources = baseSources.length > 0
+    ? baseSources.map((source, index) =>
+        normalizeEnvironmentLightSource(source, index, fallback)
+      )
+    : [normalizeEnvironmentLightSource(fallback, 0, fallback)];
+  return Object.freeze(normalizedSources);
+}
+
+function findDominantEnvironmentLightSource(sources) {
+  return sources.reduce((dominant, source) =>
+    source.luminance > dominant.luminance ? source : dominant
+  );
+}
+
+function createEnvironmentMissLighting(source, environmentColor) {
+  const fallbackRadiance = readPositiveColor(environmentColor, source.radiance);
+  const radiance = ensureNonNullColor(source.radiance, fallbackRadiance);
+  const color = readPositiveColor(source.color, environmentColor);
+  return Object.freeze({
+    sourceId: source.id,
+    kind: source.kind,
+    role: source.role,
+    contribution: "inferred-environment",
+    startingPoint: "environment-miss",
+    direction: source.direction,
+    position: source.position,
+    color,
+    intensity: Math.max(source.intensity, 0.0001),
+    radiance,
+    luminance: Math.max(colorLuminance(radiance), 0.0001),
+  });
+}
+
 const environmentLightingPresets = Object.freeze({
-  "moonlit-harbor": Object.freeze({
+  "moonlit-harbor": defineEnvironmentPreset({
     preset: "moonlit-harbor",
+    scene: "harbor",
+    timeOfDay: "night",
     environmentMode: 0,
     environmentIntensity: 0.86,
     exposure: 1,
@@ -203,9 +526,30 @@ const environmentLightingPresets = Object.freeze({
     sunDirection: Object.freeze(normalizeVector3([0.22, 0.88, 0.42], [0, 1, 0])),
     sunColor: freezeVec4([2.1, 2.25, 2.65, 1]),
     ambientColor: freezeVec4([0.018, 0.023, 0.03, 1]),
+    environmentLightSources: [
+      {
+        id: "harbor-moon",
+        kind: "moon",
+        role: "key",
+        direction: [0.22, 0.88, 0.42],
+        color: [0.7, 0.76, 0.9, 1],
+        intensity: 2.2,
+        angularRadiusRadians: 0.018,
+      },
+      {
+        id: "harbor-sky",
+        kind: "sky",
+        role: "fill",
+        direction: [0, 1, 0],
+        color: [0.22, 0.31, 0.48, 1],
+        intensity: 0.35,
+      },
+    ],
   }),
-  "product-studio": Object.freeze({
+  "product-studio": defineEnvironmentPreset({
     preset: "product-studio",
+    scene: "studio",
+    timeOfDay: "midday",
     environmentMode: 1,
     environmentIntensity: 1.05,
     exposure: 1,
@@ -214,9 +558,31 @@ const environmentLightingPresets = Object.freeze({
     sunDirection: Object.freeze(normalizeVector3([0.18, 0.93, 0.24], [0, 1, 0])),
     sunColor: freezeVec4([3.8, 3.55, 2.85, 1]),
     ambientColor: freezeVec4([0.024, 0.027, 0.03, 1]),
+    environmentLightSources: [
+      {
+        id: "studio-key-softbox",
+        kind: "studio-softbox",
+        role: "key",
+        direction: [0.18, 0.93, 0.24],
+        color: [1, 0.94, 0.82, 1],
+        intensity: 4.1,
+        angularRadiusRadians: 0.42,
+      },
+      {
+        id: "studio-fill-panel",
+        kind: "studio-softbox",
+        role: "fill",
+        direction: [-0.56, 0.62, -0.2],
+        color: [0.75, 0.84, 1, 1],
+        intensity: 1.3,
+        angularRadiusRadians: 0.55,
+      },
+    ],
   }),
-  "neutral-studio": Object.freeze({
+  "neutral-studio": defineEnvironmentPreset({
     preset: "neutral-studio",
+    scene: "studio",
+    timeOfDay: "midday",
     environmentMode: 2,
     environmentIntensity: 0.95,
     exposure: 1,
@@ -225,13 +591,339 @@ const environmentLightingPresets = Object.freeze({
     sunDirection: Object.freeze(normalizeVector3([-0.24, 0.86, 0.36], [0, 1, 0])),
     sunColor: freezeVec4([2.4, 2.35, 2.2, 1]),
     ambientColor: freezeVec4([0.028, 0.029, 0.03, 1]),
+    environmentLightSources: [
+      {
+        id: "neutral-studio-overhead",
+        kind: "studio-softbox",
+        role: "key",
+        direction: [-0.24, 0.86, 0.36],
+        color: [0.96, 0.97, 1, 1],
+        intensity: 2.5,
+        angularRadiusRadians: 0.5,
+      },
+      {
+        id: "neutral-studio-wall-bounce",
+        kind: "ground-bounce",
+        role: "fill",
+        direction: [0.2, 0.3, -0.9],
+        color: [0.55, 0.58, 0.62, 1],
+        intensity: 0.8,
+      },
+    ],
+  }),
+  "grass-field-dawn": defineEnvironmentPreset({
+    preset: "grass-field-dawn",
+    scene: "grass-field",
+    timeOfDay: "dawn",
+    environmentMode: 3,
+    environmentIntensity: 0.92,
+    exposure: 1.06,
+    horizonColor: [0.92, 0.54, 0.32, 1],
+    zenithColor: [0.16, 0.28, 0.5, 1],
+    sunDirection: [0.64, 0.32, 0.18],
+    sunColor: [5.6, 3.15, 1.55, 1],
+    ambientColor: [0.034, 0.047, 0.032, 1],
+    environmentLightSources: [
+      { id: "field-dawn-sun", kind: "sun", role: "key", direction: [0.64, 0.32, 0.18], color: [1, 0.58, 0.28, 1], intensity: 5.6, angularRadiusRadians: 0.012 },
+      { id: "field-dawn-sky", kind: "sky", role: "fill", direction: [0, 1, 0], color: [0.36, 0.52, 0.82, 1], intensity: 0.9 },
+      { id: "field-dawn-grass-bounce", kind: "ground-bounce", role: "bounce", direction: [0, 0.25, 0.1], color: [0.22, 0.44, 0.12, 1], intensity: 0.45 },
+    ],
+  }),
+  "grass-field-midday": defineEnvironmentPreset({
+    preset: "grass-field-midday",
+    scene: "grass-field",
+    timeOfDay: "midday",
+    environmentMode: 4,
+    environmentIntensity: 1.18,
+    exposure: 0.96,
+    horizonColor: [0.58, 0.78, 0.96, 1],
+    zenithColor: [0.1, 0.34, 0.82, 1],
+    sunDirection: [0.18, 0.98, 0.08],
+    sunColor: [9.8, 9.4, 8.55, 1],
+    ambientColor: [0.048, 0.062, 0.04, 1],
+    environmentLightSources: [
+      { id: "field-midday-sun", kind: "sun", role: "key", direction: [0.18, 0.98, 0.08], color: [1, 0.96, 0.86, 1], intensity: 9.8, angularRadiusRadians: 0.0093 },
+      { id: "field-midday-sky", kind: "sky", role: "fill", direction: [0, 1, 0], color: [0.48, 0.7, 1, 1], intensity: 1.8 },
+      { id: "field-midday-ground", kind: "ground-bounce", role: "bounce", direction: [0, 0.35, -0.15], color: [0.28, 0.56, 0.16, 1], intensity: 0.65 },
+    ],
+  }),
+  "grass-field-dusk": defineEnvironmentPreset({
+    preset: "grass-field-dusk",
+    scene: "grass-field",
+    timeOfDay: "dusk",
+    environmentMode: 5,
+    environmentIntensity: 0.82,
+    exposure: 1.12,
+    horizonColor: [1.08, 0.42, 0.24, 1],
+    zenithColor: [0.09, 0.1, 0.32, 1],
+    sunDirection: [-0.76, 0.24, 0.22],
+    sunColor: [4.8, 1.65, 0.72, 1],
+    ambientColor: [0.026, 0.026, 0.034, 1],
+    environmentLightSources: [
+      { id: "field-dusk-sun", kind: "sun", role: "key", direction: [-0.76, 0.24, 0.22], color: [1, 0.34, 0.16, 1], intensity: 4.8, angularRadiusRadians: 0.014 },
+      { id: "field-dusk-horizon", kind: "horizon-glow", role: "fill", direction: [-0.9, 0.08, 0.1], color: [0.92, 0.28, 0.16, 1], intensity: 1.2 },
+      { id: "field-dusk-grass", kind: "ground-bounce", role: "bounce", direction: [0, 0.22, 0.2], color: [0.12, 0.28, 0.11, 1], intensity: 0.35 },
+    ],
+  }),
+  "grass-field-night": defineEnvironmentPreset({
+    preset: "grass-field-night",
+    scene: "grass-field",
+    timeOfDay: "night",
+    environmentMode: 6,
+    environmentIntensity: 0.48,
+    exposure: 1.35,
+    horizonColor: [0.08, 0.13, 0.2, 1],
+    zenithColor: [0.018, 0.035, 0.09, 1],
+    sunDirection: [-0.22, 0.86, -0.34],
+    sunColor: [0.72, 0.82, 1.35, 1],
+    ambientColor: [0.012, 0.017, 0.026, 1],
+    environmentLightSources: [
+      { id: "field-night-moon", kind: "moon", role: "key", direction: [-0.22, 0.86, -0.34], color: [0.52, 0.62, 1, 1], intensity: 1.25, angularRadiusRadians: 0.018 },
+      { id: "field-night-stars", kind: "stars", role: "fill", direction: [0, 1, 0], color: [0.32, 0.38, 0.6, 1], intensity: 0.24 },
+      { id: "field-night-horizon", kind: "horizon-glow", role: "rim", direction: [0.8, 0.08, -0.15], color: [0.08, 0.14, 0.26, 1], intensity: 0.28 },
+    ],
+  }),
+  "forest-dawn": defineEnvironmentPreset({
+    preset: "forest-dawn",
+    scene: "forest",
+    timeOfDay: "dawn",
+    environmentMode: 7,
+    environmentIntensity: 0.78,
+    exposure: 1.14,
+    horizonColor: [0.72, 0.48, 0.28, 1],
+    zenithColor: [0.08, 0.18, 0.18, 1],
+    sunDirection: [0.58, 0.42, -0.24],
+    sunColor: [4.4, 2.65, 1.32, 1],
+    ambientColor: [0.024, 0.04, 0.026, 1],
+    environmentLightSources: [
+      { id: "forest-dawn-sun-shaft", kind: "sun", role: "key", direction: [0.58, 0.42, -0.24], color: [1, 0.62, 0.32, 1], intensity: 4.4, angularRadiusRadians: 0.018 },
+      { id: "forest-dawn-canopy", kind: "canopy-transmission", role: "filter", direction: [0.12, 0.78, 0.2], color: [0.34, 0.68, 0.24, 1], intensity: 0.86 },
+      { id: "forest-dawn-sky-gap", kind: "sky", role: "fill", direction: [-0.18, 0.92, 0.12], color: [0.28, 0.46, 0.62, 1], intensity: 0.48 },
+    ],
+  }),
+  "forest-midday": defineEnvironmentPreset({
+    preset: "forest-midday",
+    scene: "forest",
+    timeOfDay: "midday",
+    environmentMode: 8,
+    environmentIntensity: 0.96,
+    exposure: 1.02,
+    horizonColor: [0.38, 0.62, 0.42, 1],
+    zenithColor: [0.08, 0.28, 0.32, 1],
+    sunDirection: [0.08, 0.96, -0.18],
+    sunColor: [7.2, 6.9, 5.25, 1],
+    ambientColor: [0.034, 0.055, 0.032, 1],
+    environmentLightSources: [
+      { id: "forest-midday-sun-gap", kind: "sun", role: "key", direction: [0.08, 0.96, -0.18], color: [1, 0.96, 0.74, 1], intensity: 7.2, angularRadiusRadians: 0.013 },
+      { id: "forest-midday-leaves", kind: "canopy-transmission", role: "filter", direction: [0.32, 0.75, 0.12], color: [0.24, 0.72, 0.28, 1], intensity: 1.35 },
+      { id: "forest-midday-floor", kind: "ground-bounce", role: "bounce", direction: [-0.1, 0.25, 0.18], color: [0.18, 0.35, 0.13, 1], intensity: 0.42 },
+    ],
+  }),
+  "forest-dusk": defineEnvironmentPreset({
+    preset: "forest-dusk",
+    scene: "forest",
+    timeOfDay: "dusk",
+    environmentMode: 9,
+    environmentIntensity: 0.68,
+    exposure: 1.2,
+    horizonColor: [0.72, 0.28, 0.2, 1],
+    zenithColor: [0.04, 0.07, 0.18, 1],
+    sunDirection: [-0.7, 0.28, -0.18],
+    sunColor: [3.2, 1.18, 0.56, 1],
+    ambientColor: [0.018, 0.026, 0.024, 1],
+    environmentLightSources: [
+      { id: "forest-dusk-horizon", kind: "horizon-glow", role: "key", direction: [-0.7, 0.18, -0.18], color: [1, 0.34, 0.2, 1], intensity: 2.2, angularRadiusRadians: 0.1 },
+      { id: "forest-dusk-canopy", kind: "canopy-transmission", role: "filter", direction: [0.18, 0.7, 0.26], color: [0.18, 0.38, 0.2, 1], intensity: 0.52 },
+      { id: "forest-dusk-sky-gap", kind: "sky", role: "fill", direction: [0, 1, 0], color: [0.12, 0.16, 0.34, 1], intensity: 0.42 },
+    ],
+  }),
+  "forest-night": defineEnvironmentPreset({
+    preset: "forest-night",
+    scene: "forest",
+    timeOfDay: "night",
+    environmentMode: 10,
+    environmentIntensity: 0.42,
+    exposure: 1.42,
+    horizonColor: [0.035, 0.08, 0.1, 1],
+    zenithColor: [0.012, 0.025, 0.06, 1],
+    sunDirection: [0.2, 0.82, -0.46],
+    sunColor: [0.42, 0.56, 1.1, 1],
+    ambientColor: [0.01, 0.016, 0.02, 1],
+    environmentLightSources: [
+      { id: "forest-night-moon-gap", kind: "moon", role: "key", direction: [0.2, 0.82, -0.46], color: [0.42, 0.56, 1, 1], intensity: 0.95, angularRadiusRadians: 0.025 },
+      { id: "forest-night-canopy", kind: "canopy-transmission", role: "filter", direction: [-0.16, 0.66, 0.1], color: [0.08, 0.18, 0.12, 1], intensity: 0.28 },
+      { id: "forest-night-stars", kind: "stars", role: "fill", direction: [0, 1, 0], color: [0.22, 0.28, 0.5, 1], intensity: 0.18 },
+    ],
+  }),
+  "warehouse-dawn": defineEnvironmentPreset({
+    preset: "warehouse-dawn",
+    scene: "warehouse",
+    timeOfDay: "dawn",
+    environmentMode: 11,
+    environmentIntensity: 0.74,
+    exposure: 1.08,
+    horizonColor: [0.58, 0.44, 0.34, 1],
+    zenithColor: [0.16, 0.19, 0.24, 1],
+    sunDirection: [0.82, 0.28, 0.18],
+    sunColor: [2.8, 1.7, 0.92, 1],
+    ambientColor: [0.028, 0.03, 0.032, 1],
+    environmentLightSources: [
+      { id: "warehouse-dawn-loading-door", kind: "window-portal", role: "key", direction: [0.82, 0.28, 0.18], color: [1, 0.62, 0.34, 1], intensity: 2.8, angularRadiusRadians: 0.22 },
+      { id: "warehouse-dawn-fluorescent", kind: "fluorescent-strip", role: "fill", direction: [0, 1, 0], color: [0.78, 0.9, 1, 1], intensity: 1.1, angularRadiusRadians: 0.35 },
+      { id: "warehouse-dawn-concrete-bounce", kind: "ground-bounce", role: "bounce", direction: [0, 0.28, -0.2], color: [0.34, 0.36, 0.38, 1], intensity: 0.42 },
+    ],
+  }),
+  "warehouse-midday": defineEnvironmentPreset({
+    preset: "warehouse-midday",
+    scene: "warehouse",
+    timeOfDay: "midday",
+    environmentMode: 12,
+    environmentIntensity: 0.92,
+    exposure: 0.98,
+    horizonColor: [0.64, 0.7, 0.74, 1],
+    zenithColor: [0.28, 0.34, 0.42, 1],
+    sunDirection: [0.35, 0.86, 0.16],
+    sunColor: [4.2, 4, 3.45, 1],
+    ambientColor: [0.034, 0.036, 0.038, 1],
+    environmentLightSources: [
+      { id: "warehouse-midday-skylights", kind: "window-portal", role: "key", direction: [0.35, 0.86, 0.16], color: [0.92, 0.96, 1, 1], intensity: 4.2, angularRadiusRadians: 0.18 },
+      { id: "warehouse-midday-fluorescent", kind: "fluorescent-strip", role: "fill", direction: [-0.2, 0.92, 0.1], color: [0.78, 0.92, 1, 1], intensity: 1.6, angularRadiusRadians: 0.45 },
+      { id: "warehouse-midday-door-spill", kind: "sodium-door", role: "rim", direction: [-0.82, 0.18, -0.12], color: [1, 0.58, 0.24, 1], intensity: 0.68 },
+    ],
+  }),
+  "warehouse-dusk": defineEnvironmentPreset({
+    preset: "warehouse-dusk",
+    scene: "warehouse",
+    timeOfDay: "dusk",
+    environmentMode: 13,
+    environmentIntensity: 0.7,
+    exposure: 1.16,
+    horizonColor: [0.7, 0.32, 0.24, 1],
+    zenithColor: [0.08, 0.1, 0.18, 1],
+    sunDirection: [-0.78, 0.18, 0.16],
+    sunColor: [2.4, 0.94, 0.48, 1],
+    ambientColor: [0.022, 0.024, 0.03, 1],
+    environmentLightSources: [
+      { id: "warehouse-dusk-door-glow", kind: "sodium-door", role: "key", direction: [-0.78, 0.18, 0.16], color: [1, 0.42, 0.2, 1], intensity: 2.4, angularRadiusRadians: 0.18 },
+      { id: "warehouse-dusk-fluorescent", kind: "fluorescent-strip", role: "fill", direction: [0, 0.95, -0.08], color: [0.72, 0.88, 1, 1], intensity: 1.35, angularRadiusRadians: 0.4 },
+      { id: "warehouse-dusk-emergency", kind: "emergency-beacon", role: "accent", direction: [0.2, 0.35, -0.8], color: [1, 0.08, 0.04, 1], intensity: 0.32 },
+    ],
+  }),
+  "warehouse-night": defineEnvironmentPreset({
+    preset: "warehouse-night",
+    scene: "warehouse",
+    timeOfDay: "night",
+    environmentMode: 14,
+    environmentIntensity: 0.58,
+    exposure: 1.28,
+    horizonColor: [0.06, 0.08, 0.12, 1],
+    zenithColor: [0.02, 0.03, 0.055, 1],
+    sunDirection: [0.1, 0.94, -0.12],
+    sunColor: [1.2, 1.65, 2.25, 1],
+    ambientColor: [0.014, 0.018, 0.024, 1],
+    environmentLightSources: [
+      { id: "warehouse-night-fluorescent", kind: "fluorescent-strip", role: "key", direction: [0.1, 0.94, -0.12], color: [0.68, 0.88, 1, 1], intensity: 2.25, angularRadiusRadians: 0.5 },
+      { id: "warehouse-night-emergency", kind: "emergency-beacon", role: "accent", direction: [-0.4, 0.3, 0.7], color: [1, 0.05, 0.025, 1], intensity: 0.4 },
+      { id: "warehouse-night-door-leak", kind: "window-portal", role: "rim", direction: [0.82, 0.08, -0.2], color: [0.12, 0.22, 0.42, 1], intensity: 0.34 },
+    ],
+  }),
+  "cavern-dawn": defineEnvironmentPreset({
+    preset: "cavern-dawn",
+    scene: "cavern",
+    timeOfDay: "dawn",
+    environmentMode: 15,
+    environmentIntensity: 0.62,
+    exposure: 1.24,
+    horizonColor: [0.5, 0.3, 0.2, 1],
+    zenithColor: [0.04, 0.07, 0.09, 1],
+    sunDirection: [0.72, 0.32, 0.26],
+    sunColor: [2.1, 1.22, 0.64, 1],
+    ambientColor: [0.018, 0.018, 0.016, 1],
+    environmentLightSources: [
+      { id: "cavern-dawn-mouth", kind: "cave-mouth", role: "key", direction: [0.72, 0.32, 0.26], color: [1, 0.58, 0.3, 1], intensity: 2.1, angularRadiusRadians: 0.24 },
+      { id: "cavern-dawn-torch", kind: "torch", role: "emissive", direction: [-0.35, 0.28, -0.6], color: [1, 0.42, 0.16, 1], intensity: 1.35, reach: 18 },
+      { id: "cavern-dawn-crystal", kind: "crystal", role: "accent", direction: [0.08, 0.22, 0.9], color: [0.22, 0.72, 1, 1], intensity: 0.28, reach: 10 },
+    ],
+  }),
+  "cavern-midday": defineEnvironmentPreset({
+    preset: "cavern-midday",
+    scene: "cavern",
+    timeOfDay: "midday",
+    environmentMode: 16,
+    environmentIntensity: 0.72,
+    exposure: 1.16,
+    horizonColor: [0.6, 0.56, 0.48, 1],
+    zenithColor: [0.08, 0.12, 0.14, 1],
+    sunDirection: [0.36, 0.82, 0.14],
+    sunColor: [3.4, 3.05, 2.2, 1],
+    ambientColor: [0.02, 0.022, 0.02, 1],
+    environmentLightSources: [
+      { id: "cavern-midday-mouth", kind: "cave-mouth", role: "key", direction: [0.36, 0.82, 0.14], color: [1, 0.9, 0.66, 1], intensity: 3.4, angularRadiusRadians: 0.18 },
+      { id: "cavern-midday-biolume", kind: "bioluminescence", role: "fill", direction: [-0.25, 0.25, 0.7], color: [0.1, 0.82, 0.64, 1], intensity: 0.46, reach: 14 },
+      { id: "cavern-midday-wet-rock", kind: "ground-bounce", role: "bounce", direction: [0.1, 0.2, -0.3], color: [0.18, 0.2, 0.18, 1], intensity: 0.22 },
+    ],
+  }),
+  "cavern-dusk": defineEnvironmentPreset({
+    preset: "cavern-dusk",
+    scene: "cavern",
+    timeOfDay: "dusk",
+    environmentMode: 17,
+    environmentIntensity: 0.56,
+    exposure: 1.32,
+    horizonColor: [0.46, 0.18, 0.14, 1],
+    zenithColor: [0.035, 0.045, 0.08, 1],
+    sunDirection: [-0.62, 0.22, 0.22],
+    sunColor: [1.55, 0.56, 0.28, 1],
+    ambientColor: [0.014, 0.014, 0.018, 1],
+    environmentLightSources: [
+      { id: "cavern-dusk-mouth", kind: "cave-mouth", role: "rim", direction: [-0.62, 0.22, 0.22], color: [1, 0.36, 0.18, 1], intensity: 1.55, angularRadiusRadians: 0.22 },
+      { id: "cavern-dusk-torch", kind: "torch", role: "key", direction: [0.32, 0.34, -0.54], color: [1, 0.38, 0.12, 1], intensity: 1.85, reach: 20 },
+      { id: "cavern-dusk-biolume", kind: "bioluminescence", role: "fill", direction: [-0.18, 0.18, 0.74], color: [0.08, 0.58, 0.72, 1], intensity: 0.34, reach: 12 },
+    ],
+  }),
+  "cavern-night": defineEnvironmentPreset({
+    preset: "cavern-night",
+    scene: "cavern",
+    timeOfDay: "night",
+    environmentMode: 18,
+    environmentIntensity: 0.5,
+    exposure: 1.45,
+    horizonColor: [0.025, 0.035, 0.06, 1],
+    zenithColor: [0.008, 0.014, 0.03, 1],
+    sunDirection: [0.18, 0.28, -0.68],
+    sunColor: [1.9, 0.72, 0.24, 1],
+    ambientColor: [0.01, 0.012, 0.018, 1],
+    environmentLightSources: [
+      { id: "cavern-night-torch", kind: "torch", role: "key", direction: [0.18, 0.28, -0.68], color: [1, 0.36, 0.12, 1], intensity: 1.9, reach: 18 },
+      { id: "cavern-night-biolume", kind: "bioluminescence", role: "fill", direction: [-0.32, 0.16, 0.72], color: [0.06, 0.62, 0.76, 1], intensity: 0.52, reach: 16 },
+      { id: "cavern-night-lava", kind: "lava-fissure", role: "emissive", direction: [0.42, 0.12, 0.28], color: [1, 0.18, 0.04, 1], intensity: 0.8, reach: 12 },
+    ],
   }),
 });
 
-function resolveEnvironmentPreset(name) {
+export const lightingEnvironmentPresetNames = Object.freeze(
+  Object.keys(environmentLightingPresets)
+);
+
+function resolveEnvironmentPreset(name, timeOfDay) {
   const presetName = typeof name === "string" && name.length > 0 ? name : "product-studio";
   const preset = environmentLightingPresets[presetName];
   if (!preset) {
+    if (lightingEnvironmentSceneNames.includes(presetName)) {
+      if (
+        timeOfDay != null &&
+        !lightingEnvironmentTimeOfDayNames.includes(timeOfDay)
+      ) {
+        throw new Error(
+          `timeOfDay must be one of: ${lightingEnvironmentTimeOfDayNames.join(", ")}.`
+        );
+      }
+      const scenePresetName = `${presetName}-${timeOfDay ?? "midday"}`;
+      const scenePreset = environmentLightingPresets[scenePresetName];
+      if (scenePreset) {
+        return scenePreset;
+      }
+    }
     throw new Error(
       `Unknown lighting environment preset "${presetName}". Expected one of: ${lightingEnvironmentPresetNames.join(", ")}.`
     );
@@ -244,22 +936,34 @@ function estimateEnvironmentColor(config) {
   const zenithWeight = 1 - horizonWeight;
   const glowWeight = 0.055;
   const intensity = Math.max(config.environmentIntensity, 0.0001);
-  return freezeVec4([
+  return ensureNonNullColor([
     (config.horizonColor[0] * horizonWeight + config.zenithColor[0] * zenithWeight + config.sunColor[0] * glowWeight) * intensity,
     (config.horizonColor[1] * horizonWeight + config.zenithColor[1] * zenithWeight + config.sunColor[1] * glowWeight) * intensity,
     (config.horizonColor[2] * horizonWeight + config.zenithColor[2] * zenithWeight + config.sunColor[2] * glowWeight) * intensity,
     1,
-  ]);
+  ], config.dominantLightSource?.radiance ?? config.sunColor);
 }
 
 export function createEnvironmentLightingConfig(options = {}) {
-  const preset = resolveEnvironmentPreset(options.preset ?? options.name);
+  const preset = resolveEnvironmentPreset(
+    options.preset ?? options.name ?? options.scene,
+    options.timeOfDay
+  );
+  const environmentPortals = normalizeEnvironmentPortals(
+    options.environmentPortals ?? options.portals
+  );
+  const environmentPortalMode = normalizeEnvironmentPortalMode(
+    options.environmentPortalMode ?? options.portalMode,
+    environmentPortals.length > 0
+  );
   const environmentIntensity = Math.max(
     readFinite(options.environmentIntensity ?? options.intensity, preset.environmentIntensity),
     0.0001
   );
-  const config = {
+  const baseConfig = {
     preset: preset.preset,
+    scene: preset.scene,
+    timeOfDay: preset.timeOfDay,
     profile: typeof options.profile === "string" ? options.profile : defaultLightingProfile,
     environmentMode: Math.max(0, Math.trunc(readFinite(options.environmentMode, preset.environmentMode))),
     environmentIntensity,
@@ -271,15 +975,42 @@ export function createEnvironmentLightingConfig(options = {}) {
     ),
     sunColor: readColor(options.sunColor, preset.sunColor),
     ambientColor: readColor(options.ambientColor, preset.ambientColor),
+    environmentPortalMode,
+    environmentPortals,
+  };
+  const environmentLightSources = normalizeEnvironmentLightSources(
+    options.environmentLightSources ?? options.lightSources,
+    preset,
+    baseConfig
+  );
+  const dominantLightSource = findDominantEnvironmentLightSource(
+    environmentLightSources
+  );
+  const config = {
+    ...baseConfig,
+    environmentLightSources,
+    lightSources: environmentLightSources,
+    dominantLightSource,
   };
   const environmentColor = estimateEnvironmentColor(config);
+  const environmentMissLighting = createEnvironmentMissLighting(
+    dominantLightSource,
+    environmentColor
+  );
 
   return Object.freeze({
     ...config,
     environmentColor,
+    environmentMissLighting,
     wavefront: Object.freeze({
       environmentColor,
       ambientColor: config.ambientColor,
+      environmentPortalMode: config.environmentPortalMode,
+      environmentPortals: config.environmentPortals,
+      environmentLightSources: config.environmentLightSources,
+      lightSources: config.environmentLightSources,
+      dominantLightSource,
+      environmentMissLighting,
       environmentLighting: Object.freeze({
         horizonColor: config.horizonColor,
         zenithColor: config.zenithColor,
@@ -288,6 +1019,12 @@ export function createEnvironmentLightingConfig(options = {}) {
         intensity: config.environmentIntensity,
         mode: config.environmentMode,
         exposure: config.exposure,
+        environmentPortalMode: config.environmentPortalMode,
+        environmentPortalCount: config.environmentPortals.length,
+        environmentLightSources: config.environmentLightSources,
+        environmentLightSourceCount: config.environmentLightSources.length,
+        dominantLightSource,
+        environmentMissLighting,
       }),
     }),
   });
@@ -298,6 +1035,12 @@ export function createWavefrontEnvironmentLightingOptions(options = {}) {
   return Object.freeze({
     environmentColor: config.wavefront.environmentColor,
     ambientColor: config.wavefront.ambientColor,
+    environmentPortalMode: config.wavefront.environmentPortalMode,
+    environmentPortals: config.wavefront.environmentPortals,
+    environmentLightSources: config.wavefront.environmentLightSources,
+    lightSources: config.wavefront.environmentLightSources,
+    dominantLightSource: config.wavefront.dominantLightSource,
+    environmentMissLighting: config.wavefront.environmentMissLighting,
     environmentLighting: config.wavefront.environmentLighting,
     lightingEnvironment: config,
   });

--- a/src/techniques/pathtracer/pathtrace.job.wgsl
+++ b/src/techniques/pathtracer/pathtrace.job.wgsl
@@ -182,7 +182,9 @@ fn evaluate_direct_sun(
   view_direction: vec3<f32>
 ) -> vec3<f32> {
   let surface_normal = faceforward_normal(hit.normal, -view_direction);
-  let sun_direction = safe_normalize(vec3<f32>(0.32, 0.91, 0.21));
+  let sun_direction = safe_normalize(
+    environment_key_direction(pathTracerParams.environment_mode)
+  );
   let ndotl = saturate(dot(surface_normal, sun_direction));
   if (ndotl <= 0.0) {
     return vec3<f32>(0.0);
@@ -205,7 +207,9 @@ fn evaluate_direct_sun(
     ndotl *
     PATH_TRACER_INV_PI *
     (1.0 - material.metalness);
-  let sun_color = vec3<f32>(10.0, 9.4, 8.6) * max(pathTracerParams.environment_intensity, 0.0001);
+  let sun_color =
+    environment_key_color(pathTracerParams.environment_mode) *
+    max(pathTracerParams.environment_intensity, 0.0001);
   return (diffuse + specular) * sun_color;
 }
 
@@ -319,11 +323,12 @@ fn process_job(@builtin(global_invocation_id) global_id: vec3<u32>) {
     for (var bounce_index = 0u; bounce_index < bounce_count; bounce_index = bounce_index + 1u) {
       let hit = trace_scene(ray);
       if (hit.hit == 0u) {
-        sample_radiance = sample_radiance + throughput * environment_radiance(
+        let environment_sample = environment_radiance(
           ray.direction,
           pathTracerParams.environment_intensity,
           pathTracerParams.environment_mode
         );
+        sample_radiance = sample_radiance + throughput * environment_sample;
         terminal_origin = ray.origin;
         terminal_direction = ray.direction;
         current_hit_kind = 0u;
@@ -342,7 +347,15 @@ fn process_job(@builtin(global_invocation_id) global_id: vec3<u32>) {
         captured_primary_hit = true;
       }
 
-      sample_radiance = sample_radiance + throughput * material.emission;
+      let emissive_radiance = sanitize_radiance(material.emission);
+      if (luminance(emissive_radiance) > 0.0001) {
+        sample_radiance = sample_radiance + throughput * emissive_radiance;
+        terminal_origin = hit.position;
+        terminal_direction = ray.direction;
+        current_hit_kind = hit.primitive_kind;
+        break;
+      }
+
       if (pathTracerParams.enable_next_event_estimation != 0u) {
         sample_radiance = sample_radiance + throughput * evaluate_direct_sun(
           hit,

--- a/src/techniques/pathtracer/prelude.wgsl
+++ b/src/techniques/pathtracer/prelude.wgsl
@@ -142,6 +142,19 @@ fn saturate(value: f32) -> f32 {
   return clamp(value, 0.0, 1.0);
 }
 
+fn sanitize_radiance(value: vec3<f32>) -> vec3<f32> {
+  return max(value, vec3<f32>(0.0));
+}
+
+fn ensure_non_null_radiance(value: vec3<f32>) -> vec3<f32> {
+  let radiance = sanitize_radiance(value);
+  if (luminance(radiance) <= 0.000001) {
+    return vec3<f32>(0.0001);
+  }
+
+  return radiance;
+}
+
 fn safe_rcp(value: f32) -> f32 {
   if (abs(value) <= PATH_TRACER_EPSILON) {
     return 0.0;
@@ -170,7 +183,7 @@ fn unpack_material(material: PathTracerMaterial) -> MaterialSample {
   return MaterialSample(
     material.albedo_roughness.xyz,
     clamp(material.albedo_roughness.w, 0.02, 1.0),
-    material.emission_metalness.xyz,
+    sanitize_radiance(material.emission_metalness.xyz),
     saturate(material.emission_metalness.w),
     material.transmittance_ior.xyz,
     max(material.transmittance_ior.w, 1.0)
@@ -229,32 +242,182 @@ fn fresnel_schlick(cos_theta: f32, f0: vec3<f32>) -> vec3<f32> {
   return f0 + (vec3<f32>(1.0) - f0) * factor;
 }
 
+fn environment_horizon_color(mode: u32) -> vec3<f32> {
+  var color = vec3<f32>(0.65, 0.74, 0.86);
+  if (mode == 0u) { color = vec3<f32>(0.33, 0.43, 0.53); }
+  if (mode == 1u) { color = vec3<f32>(0.52, 0.61, 0.65); }
+  if (mode == 2u) { color = vec3<f32>(0.48, 0.53, 0.55); }
+  if (mode == 3u) { color = vec3<f32>(0.92, 0.54, 0.32); }
+  if (mode == 4u) { color = vec3<f32>(0.58, 0.78, 0.96); }
+  if (mode == 5u) { color = vec3<f32>(1.08, 0.42, 0.24); }
+  if (mode == 6u) { color = vec3<f32>(0.08, 0.13, 0.2); }
+  if (mode == 7u) { color = vec3<f32>(0.72, 0.48, 0.28); }
+  if (mode == 8u) { color = vec3<f32>(0.38, 0.62, 0.42); }
+  if (mode == 9u) { color = vec3<f32>(0.72, 0.28, 0.2); }
+  if (mode == 10u) { color = vec3<f32>(0.035, 0.08, 0.1); }
+  if (mode == 11u) { color = vec3<f32>(0.58, 0.44, 0.34); }
+  if (mode == 12u) { color = vec3<f32>(0.64, 0.7, 0.74); }
+  if (mode == 13u) { color = vec3<f32>(0.7, 0.32, 0.24); }
+  if (mode == 14u) { color = vec3<f32>(0.06, 0.08, 0.12); }
+  if (mode == 15u) { color = vec3<f32>(0.5, 0.3, 0.2); }
+  if (mode == 16u) { color = vec3<f32>(0.6, 0.56, 0.48); }
+  if (mode == 17u) { color = vec3<f32>(0.46, 0.18, 0.14); }
+  if (mode == 18u) { color = vec3<f32>(0.025, 0.035, 0.06); }
+  return ensure_non_null_radiance(color);
+}
+
+fn environment_zenith_color(mode: u32) -> vec3<f32> {
+  var color = vec3<f32>(0.05, 0.12, 0.24);
+  if (mode == 0u) { color = vec3<f32>(0.035, 0.07, 0.14); }
+  if (mode == 1u) { color = vec3<f32>(0.18, 0.22, 0.26); }
+  if (mode == 2u) { color = vec3<f32>(0.24, 0.26, 0.29); }
+  if (mode == 3u) { color = vec3<f32>(0.16, 0.28, 0.5); }
+  if (mode == 4u) { color = vec3<f32>(0.1, 0.34, 0.82); }
+  if (mode == 5u) { color = vec3<f32>(0.09, 0.1, 0.32); }
+  if (mode == 6u) { color = vec3<f32>(0.018, 0.035, 0.09); }
+  if (mode == 7u) { color = vec3<f32>(0.08, 0.18, 0.18); }
+  if (mode == 8u) { color = vec3<f32>(0.08, 0.28, 0.32); }
+  if (mode == 9u) { color = vec3<f32>(0.04, 0.07, 0.18); }
+  if (mode == 10u) { color = vec3<f32>(0.012, 0.025, 0.06); }
+  if (mode == 11u) { color = vec3<f32>(0.16, 0.19, 0.24); }
+  if (mode == 12u) { color = vec3<f32>(0.28, 0.34, 0.42); }
+  if (mode == 13u) { color = vec3<f32>(0.08, 0.1, 0.18); }
+  if (mode == 14u) { color = vec3<f32>(0.02, 0.03, 0.055); }
+  if (mode == 15u) { color = vec3<f32>(0.04, 0.07, 0.09); }
+  if (mode == 16u) { color = vec3<f32>(0.08, 0.12, 0.14); }
+  if (mode == 17u) { color = vec3<f32>(0.035, 0.045, 0.08); }
+  if (mode == 18u) { color = vec3<f32>(0.008, 0.014, 0.03); }
+  return ensure_non_null_radiance(color);
+}
+
+fn environment_key_direction(mode: u32) -> vec3<f32> {
+  var direction = vec3<f32>(0.35, 0.92, 0.18);
+  if (mode == 0u) { direction = vec3<f32>(0.22, 0.88, 0.42); }
+  if (mode == 1u) { direction = vec3<f32>(0.18, 0.93, 0.24); }
+  if (mode == 2u) { direction = vec3<f32>(-0.24, 0.86, 0.36); }
+  if (mode == 3u) { direction = vec3<f32>(0.64, 0.32, 0.18); }
+  if (mode == 4u) { direction = vec3<f32>(0.18, 0.98, 0.08); }
+  if (mode == 5u) { direction = vec3<f32>(-0.76, 0.24, 0.22); }
+  if (mode == 6u) { direction = vec3<f32>(-0.22, 0.86, -0.34); }
+  if (mode == 7u) { direction = vec3<f32>(0.58, 0.42, -0.24); }
+  if (mode == 8u) { direction = vec3<f32>(0.08, 0.96, -0.18); }
+  if (mode == 9u) { direction = vec3<f32>(-0.7, 0.18, -0.18); }
+  if (mode == 10u) { direction = vec3<f32>(0.2, 0.82, -0.46); }
+  if (mode == 11u) { direction = vec3<f32>(0.82, 0.28, 0.18); }
+  if (mode == 12u) { direction = vec3<f32>(0.35, 0.86, 0.16); }
+  if (mode == 13u) { direction = vec3<f32>(-0.78, 0.18, 0.16); }
+  if (mode == 14u) { direction = vec3<f32>(0.1, 0.94, -0.12); }
+  if (mode == 15u) { direction = vec3<f32>(0.72, 0.32, 0.26); }
+  if (mode == 16u) { direction = vec3<f32>(0.36, 0.82, 0.14); }
+  if (mode == 17u) { direction = vec3<f32>(0.32, 0.34, -0.54); }
+  if (mode == 18u) { direction = vec3<f32>(0.18, 0.28, -0.68); }
+  return safe_normalize(direction);
+}
+
+fn environment_fill_direction(mode: u32) -> vec3<f32> {
+  var direction = vec3<f32>(0.0, 1.0, 0.0);
+  if (mode == 3u || mode == 4u || mode == 5u) { direction = vec3<f32>(0.0, 0.35, 0.1); }
+  if (mode == 6u) { direction = vec3<f32>(0.0, 1.0, 0.0); }
+  if (mode >= 7u && mode <= 10u) { direction = vec3<f32>(0.18, 0.75, 0.2); }
+  if (mode >= 11u && mode <= 14u) { direction = vec3<f32>(0.0, 0.95, -0.08); }
+  if (mode >= 15u && mode <= 18u) { direction = vec3<f32>(-0.25, 0.22, 0.7); }
+  return safe_normalize(direction);
+}
+
+fn environment_key_color(mode: u32) -> vec3<f32> {
+  var color = vec3<f32>(8.0, 7.6, 6.8);
+  if (mode == 0u) { color = vec3<f32>(0.7, 0.76, 0.9) * 2.2; }
+  if (mode == 1u) { color = vec3<f32>(1.0, 0.94, 0.82) * 4.1; }
+  if (mode == 2u) { color = vec3<f32>(0.96, 0.97, 1.0) * 2.5; }
+  if (mode == 3u) { color = vec3<f32>(1.0, 0.58, 0.28) * 5.6; }
+  if (mode == 4u) { color = vec3<f32>(1.0, 0.96, 0.86) * 9.8; }
+  if (mode == 5u) { color = vec3<f32>(1.0, 0.34, 0.16) * 4.8; }
+  if (mode == 6u) { color = vec3<f32>(0.52, 0.62, 1.0) * 1.25; }
+  if (mode == 7u) { color = vec3<f32>(1.0, 0.62, 0.32) * 4.4; }
+  if (mode == 8u) { color = vec3<f32>(1.0, 0.96, 0.74) * 7.2; }
+  if (mode == 9u) { color = vec3<f32>(1.0, 0.34, 0.2) * 2.2; }
+  if (mode == 10u) { color = vec3<f32>(0.42, 0.56, 1.0) * 0.95; }
+  if (mode == 11u) { color = vec3<f32>(1.0, 0.62, 0.34) * 2.8; }
+  if (mode == 12u) { color = vec3<f32>(0.92, 0.96, 1.0) * 4.2; }
+  if (mode == 13u) { color = vec3<f32>(1.0, 0.42, 0.2) * 2.4; }
+  if (mode == 14u) { color = vec3<f32>(0.68, 0.88, 1.0) * 2.25; }
+  if (mode == 15u) { color = vec3<f32>(1.0, 0.58, 0.3) * 2.1; }
+  if (mode == 16u) { color = vec3<f32>(1.0, 0.9, 0.66) * 3.4; }
+  if (mode == 17u) { color = vec3<f32>(1.0, 0.38, 0.12) * 1.85; }
+  if (mode == 18u) { color = vec3<f32>(1.0, 0.36, 0.12) * 1.9; }
+  return ensure_non_null_radiance(color);
+}
+
+fn environment_fill_color(mode: u32) -> vec3<f32> {
+  var color = vec3<f32>(0.3, 0.4, 0.6);
+  if (mode == 0u) { color = vec3<f32>(0.22, 0.31, 0.48) * 0.35; }
+  if (mode == 1u) { color = vec3<f32>(0.75, 0.84, 1.0) * 1.3; }
+  if (mode == 2u) { color = vec3<f32>(0.55, 0.58, 0.62) * 0.8; }
+  if (mode == 3u) { color = vec3<f32>(0.22, 0.44, 0.12) * 0.45; }
+  if (mode == 4u) { color = vec3<f32>(0.28, 0.56, 0.16) * 0.65; }
+  if (mode == 5u) { color = vec3<f32>(0.12, 0.28, 0.11) * 0.35; }
+  if (mode == 6u) { color = vec3<f32>(0.32, 0.38, 0.6) * 0.24; }
+  if (mode == 7u) { color = vec3<f32>(0.34, 0.68, 0.24) * 0.86; }
+  if (mode == 8u) { color = vec3<f32>(0.24, 0.72, 0.28) * 1.35; }
+  if (mode == 9u) { color = vec3<f32>(0.18, 0.38, 0.2) * 0.52; }
+  if (mode == 10u) { color = vec3<f32>(0.08, 0.18, 0.12) * 0.28; }
+  if (mode == 11u) { color = vec3<f32>(0.78, 0.9, 1.0) * 1.1; }
+  if (mode == 12u) { color = vec3<f32>(0.78, 0.92, 1.0) * 1.6; }
+  if (mode == 13u) { color = vec3<f32>(0.72, 0.88, 1.0) * 1.35; }
+  if (mode == 14u) { color = vec3<f32>(1.0, 0.05, 0.025) * 0.4; }
+  if (mode == 15u) { color = vec3<f32>(1.0, 0.42, 0.16) * 1.35; }
+  if (mode == 16u) { color = vec3<f32>(0.1, 0.82, 0.64) * 0.46; }
+  if (mode == 17u) { color = vec3<f32>(0.08, 0.58, 0.72) * 0.34; }
+  if (mode == 18u) { color = vec3<f32>(0.06, 0.62, 0.76) * 0.52; }
+  return ensure_non_null_radiance(color);
+}
+
+fn environment_horizon_glow(mode: u32) -> vec3<f32> {
+  var color = environment_horizon_color(mode) * 0.2;
+  if (mode == 5u || mode == 9u || mode == 13u || mode == 17u) {
+    color = color + vec3<f32>(0.8, 0.22, 0.12);
+  }
+  if (mode == 14u || mode == 18u) {
+    color = color + vec3<f32>(0.08, 0.12, 0.22);
+  }
+  return ensure_non_null_radiance(color);
+}
+
+fn environment_key_focus(mode: u32) -> f32 {
+  var focus = 192.0;
+  if (mode == 1u || mode == 2u || (mode >= 11u && mode <= 14u)) {
+    focus = 48.0;
+  }
+  if (mode >= 15u && mode <= 18u) {
+    focus = 28.0;
+  }
+  if (mode == 6u || mode == 10u) {
+    focus = 384.0;
+  }
+  return focus;
+}
+
 fn environment_radiance(
   direction: vec3<f32>,
   intensity: f32,
   mode: u32
 ) -> vec3<f32> {
   let up_factor = saturate(direction.y * 0.5 + 0.5);
-  let horizon_color = vec3<f32>(0.65, 0.74, 0.86);
-  let zenith_color = select(
-    vec3<f32>(0.05, 0.12, 0.24),
-    vec3<f32>(0.11, 0.08, 0.18),
-    mode == 1u
+  let horizon_color = environment_horizon_color(mode);
+  let zenith_color = environment_zenith_color(mode);
+  let key_direction = safe_normalize(environment_key_direction(mode));
+  let fill_direction = safe_normalize(environment_fill_direction(mode));
+  let key_glow = pow(saturate(dot(direction, key_direction)), environment_key_focus(mode));
+  let fill_glow = pow(saturate(dot(direction, fill_direction)), 32.0);
+  let horizon_band = pow(1.0 - abs(direction.y), 2.0);
+  let sky = horizon_color * (1.0 - up_factor) + zenith_color * up_factor;
+  let inferred_source =
+    environment_key_color(mode) * key_glow +
+    environment_fill_color(mode) * fill_glow * 0.35 +
+    environment_horizon_glow(mode) * horizon_band;
+  return ensure_non_null_radiance(
+    (sky + inferred_source) * max(intensity, 0.0001)
   );
-  let sunset_color = vec3<f32>(1.1, 0.64, 0.32);
-  let sun_direction = safe_normalize(vec3<f32>(0.35, 0.92, 0.18));
-  let moon_direction = safe_normalize(vec3<f32>(-0.2, 0.98, -0.1));
-  let sun_glow = pow(saturate(dot(direction, sun_direction)), 256.0);
-  let moon_glow = pow(saturate(dot(direction, moon_direction)), 512.0);
-  var sky = horizon_color * (1.0 - up_factor) + zenith_color * up_factor;
-  if (mode == 1u) {
-    sky = sky * (1.0 - up_factor * 0.4) + sunset_color * sun_glow * 0.25;
-  }
-  return (
-    sky +
-    vec3<f32>(8.0, 7.6, 6.8) * sun_glow +
-    vec3<f32>(0.7, 0.76, 0.9) * moon_glow * 0.3
-  ) * max(intensity, 0.0001);
 }
 
 fn miss_hit(ray: Ray) -> PathHit {

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -20,8 +20,13 @@ const {
   lightingProfileModeOrder,
   lightingProfileNames,
   lightingProfiles,
+  lightingEnvironmentLightSourceKinds,
+  lightingEnvironmentPortalModes,
+  lightingEnvironmentPortalShapes,
   lightingPreludeWgslUrl,
   lightingEnvironmentPresetNames,
+  lightingEnvironmentSceneNames,
+  lightingEnvironmentTimeOfDayNames,
   lightingTechniqueNames,
   lightingTechniques,
   loadLightingJobs,
@@ -88,27 +93,173 @@ test("environment lighting config exposes named presets for renderers", () => {
     intensity: 1.2,
   });
 
-  assert.deepEqual(lightingEnvironmentPresetNames, [
-    "moonlit-harbor",
-    "product-studio",
-    "neutral-studio",
-  ]);
+  assert.ok(lightingEnvironmentPresetNames.includes("product-studio"));
+  assert.ok(lightingEnvironmentPresetNames.includes("grass-field-midday"));
+  assert.ok(lightingEnvironmentPresetNames.includes("forest-dusk"));
+  assert.ok(lightingEnvironmentPresetNames.includes("warehouse-night"));
+  assert.ok(lightingEnvironmentPresetNames.includes("cavern-dawn"));
   assert.equal(config.preset, "product-studio");
   assert.equal(config.environmentIntensity, 1.2);
   assert.equal(config.wavefront.environmentLighting.intensity, 1.2);
   assert.equal(config.wavefront.environmentColor.length, 4);
   assert.equal(config.wavefront.ambientColor.length, 4);
+  assert.equal(config.wavefront.environmentPortalMode, "disabled");
+  assert.deepEqual(config.wavefront.environmentPortals, []);
   assert.ok(config.wavefront.environmentLighting.sunDirection.every(Number.isFinite));
+});
+
+test("environment presets cover outdoor, interior, and underground time-of-day variants", () => {
+  assert.deepEqual(lightingEnvironmentTimeOfDayNames, [
+    "dawn",
+    "midday",
+    "dusk",
+    "night",
+  ]);
+  assert.deepEqual(lightingEnvironmentSceneNames, [
+    "studio",
+    "harbor",
+    "grass-field",
+    "forest",
+    "warehouse",
+    "cavern",
+  ]);
+  assert.ok(lightingEnvironmentLightSourceKinds.includes("sun"));
+  assert.ok(lightingEnvironmentLightSourceKinds.includes("fluorescent-strip"));
+  assert.ok(lightingEnvironmentLightSourceKinds.includes("torch"));
+
+  const requiredScenes = ["grass-field", "forest", "warehouse", "cavern"];
+  for (const scene of requiredScenes) {
+    for (const timeOfDay of lightingEnvironmentTimeOfDayNames) {
+      const presetName = `${scene}-${timeOfDay}`;
+      assert.ok(
+        lightingEnvironmentPresetNames.includes(presetName),
+        `Missing environment preset: ${presetName}`
+      );
+      const config = createEnvironmentLightingConfig({ preset: presetName });
+      assert.equal(config.scene, scene);
+      assert.equal(config.timeOfDay, timeOfDay);
+      assert.ok(config.environmentLightSources.length >= 2);
+      assert.ok(config.dominantLightSource);
+      assert.equal(config.environmentMissLighting.sourceId, config.dominantLightSource.id);
+      assert.ok(config.environmentMissLighting.luminance > 0);
+      assert.ok(config.environmentColor.slice(0, 3).every((component) => component > 0));
+      assert.ok(
+        config.environmentLightSources.every((source) =>
+          source.radiance.slice(0, 3).every((component) => component >= 0)
+        )
+      );
+      assert.deepEqual(
+        config.wavefront.environmentLighting.environmentMissLighting,
+        config.environmentMissLighting
+      );
+    }
+  }
+});
+
+test("environment preset resolution accepts scene and time-of-day aliases", () => {
+  const config = createEnvironmentLightingConfig({
+    scene: "grass-field",
+    timeOfDay: "dawn",
+  });
+  const defaultTimeConfig = createEnvironmentLightingConfig({
+    preset: "warehouse",
+  });
+
+  assert.equal(config.preset, "grass-field-dawn");
+  assert.equal(config.scene, "grass-field");
+  assert.equal(config.timeOfDay, "dawn");
+  assert.equal(defaultTimeConfig.preset, "warehouse-midday");
+  assert.throws(
+    () =>
+      createEnvironmentLightingConfig({
+        scene: "forest",
+        timeOfDay: "afternoon",
+      }),
+    /timeOfDay must be one of/
+  );
+});
+
+test("environment lighting sources sanitize invalid color and intensity for render checks", () => {
+  const config = createEnvironmentLightingConfig({
+    preset: "cavern-night",
+    environmentLightSources: [
+      {
+        id: "broken-negative-source",
+        kind: "torch",
+        color: [-8, Number.NaN, 0, 1],
+        intensity: -4,
+        direction: [0, 0, 0],
+      },
+    ],
+  });
+
+  assert.equal(config.environmentLightSources.length, 1);
+  assert.equal(config.dominantLightSource.id, "broken-negative-source");
+  assert.ok(config.dominantLightSource.intensity > 0);
+  assert.ok(config.dominantLightSource.luminance > 0);
+  assert.ok(config.environmentMissLighting.color.slice(0, 3).every((component) => component > 0));
+  assert.ok(config.environmentMissLighting.radiance.slice(0, 3).every((component) => component > 0));
+});
+
+test("environment lighting config normalizes window portals for environment lighting", () => {
+  const config = createEnvironmentLightingConfig({
+    preset: "neutral-studio",
+    environmentPortals: [
+      {
+        id: "north-window",
+        position: [0, 1.2, -2.4],
+        normal: [0, 0, 1],
+        tangent: [1, 0, 0],
+        width: 1.8,
+        height: 1.1,
+        intensity: 1.4,
+        color: [0.85, 0.92, 1, 0.75],
+      },
+    ],
+  });
+
+  assert.deepEqual(lightingEnvironmentPortalShapes, ["rectangle"]);
+  assert.deepEqual(lightingEnvironmentPortalModes, [
+    "disabled",
+    "guide",
+    "guide-and-gate",
+  ]);
+  assert.equal(config.environmentPortalMode, "guide-and-gate");
+  assert.equal(config.environmentPortals.length, 1);
+  assert.equal(config.environmentPortals[0].id, "north-window");
+  assert.equal(config.environmentPortals[0].shape, "rectangle");
+  assert.deepEqual(config.environmentPortals[0].position, [0, 1.2, -2.4]);
+  assert.deepEqual(config.environmentPortals[0].normal, [0, 0, 1]);
+  assert.deepEqual(config.environmentPortals[0].tangent, [1, 0, 0]);
+  assert.deepEqual(config.environmentPortals[0].bitangent, [0, 1, 0]);
+  assert.equal(config.environmentPortals[0].width, 1.8);
+  assert.equal(config.environmentPortals[0].height, 1.1);
+  assert.equal(config.environmentPortals[0].radianceScale, 1.4);
+  assert.deepEqual(config.environmentPortals[0].color, [0.85, 0.92, 1, 0.75]);
+  assert.equal(config.wavefront.environmentLighting.environmentPortalCount, 1);
 });
 
 test("wavefront environment lighting options provide renderer-ready fields", () => {
   const options = createWavefrontEnvironmentLightingOptions({
     preset: "moonlit-harbor",
+    environmentPortalMode: "guide",
+    environmentPortals: [
+      {
+        center: [1, 1.4, -3],
+        normal: [0, 0, 1],
+        halfWidth: 0.5,
+        halfHeight: 0.25,
+      },
+    ],
   });
 
   assert.equal(options.lightingEnvironment.preset, "moonlit-harbor");
   assert.deepEqual(options.environmentColor, options.lightingEnvironment.environmentColor);
   assert.deepEqual(options.ambientColor, options.lightingEnvironment.ambientColor);
+  assert.equal(options.environmentPortalMode, "guide");
+  assert.equal(options.environmentPortals.length, 1);
+  assert.equal(options.environmentPortals[0].width, 1);
+  assert.equal(options.environmentPortals[0].height, 0.5);
   assert.equal(options.environmentLighting.horizonColor.length, 4);
   assert.equal(options.environmentLighting.zenithColor.length, 4);
   assert.equal(options.environmentLighting.sunColor.length, 4);
@@ -118,6 +269,20 @@ test("environment lighting config rejects unknown presets", () => {
   assert.throws(
     () => createEnvironmentLightingConfig({ preset: "unknown" }),
     /Unknown lighting environment preset/
+  );
+});
+
+test("environment lighting config rejects invalid portal settings", () => {
+  assert.throws(
+    () => createEnvironmentLightingConfig({ environmentPortalMode: "wrong" }),
+    /environmentPortalMode must be one of/
+  );
+  assert.throws(
+    () =>
+      createEnvironmentLightingConfig({
+        environmentPortals: [{ shape: "circle" }],
+      }),
+    /environmentPortals\[0\]\.shape must be one of/
   );
 });
 
@@ -178,6 +343,24 @@ test("pathtracer prelude publishes concrete scene, history, and environment cont
   assert.match(source, /struct PathTracerSceneMetadata/);
   assert.match(source, /struct PathAccumulationPixel/);
   assert.match(source, /fn environment_radiance/);
+});
+
+test("pathtracer environment and emissive paths publish non-null radiance guards", () => {
+  const base = path.resolve(
+    __dirname,
+    "..",
+    "src",
+    "techniques",
+    "pathtracer"
+  );
+  const prelude = fs.readFileSync(path.join(base, "prelude.wgsl"), "utf8");
+  const pathTrace = fs.readFileSync(path.join(base, "pathtrace.job.wgsl"), "utf8");
+
+  assert.match(prelude, /fn ensure_non_null_radiance/);
+  assert.match(prelude, /mode == 18u/);
+  assert.match(pathTrace, /let environment_sample = environment_radiance/);
+  assert.match(pathTrace, /let emissive_radiance = sanitize_radiance\(material\.emission\)/);
+  assert.match(pathTrace, /luminance\(emissive_radiance\) > 0\.0001/);
 });
 
 test("reference pathtracer WGSL stages are real kernels rather than placeholders", () => {


### PR DESCRIPTION
## Summary
- Add grass-field, forest, warehouse, and cavern environment preset families with dawn, midday, dusk, and night variants.
- Publish normalized environment light-source metadata, dominant source inference, and non-null environment-miss lighting data.
- Update pathtracer WGSL so environment misses use guarded inferred radiance and emissive hits contribute once before path termination.

## Validation
- npm run typecheck
- npm run lint
- npm run audit:npm
- npm run test:coverage
- npm run build
- npm run pack:check
- git diff --check

Refs Plasius-LTD/gpu-lighting#27