### PR TITLE
Prepare gpu-lighting 0.2.0 release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -85,7 +85,16 @@ jobs:
           fi
 
           echo "New version: $NEW_VER"
-          git push --follow-tags
+          if [ "${BUMP}" = "none" ]; then
+            if git ls-remote --exit-code --tags origin "refs/tags/${NEW_VER}" >/dev/null 2>&1; then
+              echo "Tag ${NEW_VER} already exists on origin."
+            else
+              git tag -a "$NEW_VER" -m "chore: release ${NEW_VER}"
+              git push origin "refs/tags/${NEW_VER}"
+            fi
+          else
+            git push --follow-tags
+          fi
 
           # Expose tag (vX.Y.Z) and version (X.Y.Z) for later steps
           VER_NO_V=${NEW_VER#v}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 - **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
+## [0.2.0] - 2026-06-06
+
+- **Added**
   - Added environment-light portal contracts to the reusable environment
     lighting config so renderers can guide and gate sky/HDRI contribution
     through room openings such as windows.
@@ -340,3 +354,5 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 [0.1.16]: https://github.com/Plasius-LTD/gpu-lighting/releases/tag/v0.1.16
 [0.1.17]: https://github.com/Plasius-LTD/gpu-lighting/releases/tag/v0.1.17
 [0.1.19]: https://github.com/Plasius-LTD/gpu-lighting/releases/tag/v0.1.19
+[Unreleased]: https://github.com/Plasius-LTD/gpu-lighting/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Plasius-LTD/gpu-lighting/releases/tag/v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-lighting",
-  "version": "0.1.19",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-lighting",
-      "version": "0.1.19",
+      "version": "0.2.0",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-lighting",
-  "version": "0.1.19",
+  "version": "0.2.0",
   "description": "Advanced lighting WGSL modules and planning profiles for @plasius/gpu-worker.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- Bump `@plasius/gpu-lighting` package metadata to `0.2.0` for the environment lighting preset release.
- Promote the environment lighting preset changelog entries into a `0.2.0` release section.
- Allow `cd.yml` to publish an already-prepared package version with `bump=none` by creating and pushing the matching tag without trying to push directly to protected `main`.

## Validation
- npm run typecheck
- npm run lint
- npm run audit:npm
- npm run test:coverage
- npm run build
- npm run pack:check
- git diff --check

Release follow-up for Plasius-LTD/gpu-lighting#37 and Plasius-LTD/gpu-lighting#27.