### PR TITLE
feat: expose sunlit environment baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,17 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 - **Added**
+  - Added `environmentMap`/`hdri` passthrough in wavefront lighting options so
+    renderers can use HDRI/equirectangular radiance textures as environment
+    light sources instead of relying primarily on static ambient colours.
+  - Added `sunlitBaseline` to environment lighting presets and wavefront
+    lighting options so renderers can apply a time-of-day daylight floor at
+    terminal path collisions without raising ambient residual colour.
   - (placeholder)
 
 - **Changed**
-  - (placeholder)
+  - Reduced ambient residual strength for the grass-field, forest, warehouse,
+    and cavern environment preset families to avoid low-sample whitewash.
 
 - **Fixed**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,12 @@ console.log(wavefrontLighting.environmentMissLighting.startingPoint);
 `createEnvironmentLightingConfig(...)` owns the reusable sky/environment
 semantics: horizon and zenith colours, key-light direction, key-light colour,
 environment intensity, exposure, ambient residual colour, and optional
-environment-light portals.
+environment-light portals. The grass-field, forest, warehouse, and cavern
+families use restrained ambient residual scaling so low-sample renderers keep
+some final-bounce colour without washing dark materials toward white. They also
+publish `sunlitBaseline`, a scene-scaled time-of-day daylight floor that
+renderers can use at terminal path collisions without raising the global
+ambient colour.
 
 Preset families now cover:
 
@@ -154,14 +159,18 @@ Callers can pass the combined `preset` name directly or pass `scene` plus
 `timeOfDay`; scene-only aliases default to `midday`.
 
 Each preset publishes `scene`, `timeOfDay`, normalized
-`environmentLightSources`, a `dominantLightSource`, and
+`sunlitBaseline`, `environmentLightSources`, a `dominantLightSource`, and
 `environmentMissLighting`. Source metadata includes source kind, role, direction,
 position, colour, intensity, radiance, luminance, reach, and angular radius.
 Renderers can use `environmentMissLighting` when a path ray misses scene
 geometry: the miss has an inferred source colour/brightness and a stable
 `startingPoint` of `environment-miss` instead of an unbounded null/negative sky
 sample. Emissive material hits remain explicit light-source hits and should not
-be double-counted by environment inference.
+be double-counted by environment inference. Callers can also pass an
+`environmentMap`/`hdri` descriptor; the lighting config preserves it in
+`createWavefrontEnvironmentLightingOptions(...)` so the wavefront renderer can
+sample an equirectangular radiance map for environment misses and ambient
+residuals instead of relying primarily on static ambient values.
 
 Portals describe physical openings such as windows where outside radiance can
 enter an interior. They are normalized as rectangle apertures with position,

--- a/src/index.js
+++ b/src/index.js
@@ -191,8 +191,40 @@ export const lightingDistanceBands = Object.freeze([
 export const lightingWorkerQueueClass = "lighting";
 export const lightingDebugOwner = "lighting";
 
+const environmentPresetAmbientScales = Object.freeze({
+  "grass-field": 0.78,
+  forest: 0.78,
+  warehouse: 0.82,
+  cavern: 0.78,
+});
+
+const environmentSunlitBaselineByTimeOfDay = Object.freeze({
+  dawn: 0.18,
+  midday: 0.28,
+  dusk: 0.14,
+  night: 0.035,
+});
+
+const environmentSunlitBaselineSceneScales = Object.freeze({
+  "grass-field": 1,
+  forest: 0.78,
+  warehouse: 0.62,
+  cavern: 0.42,
+  harbor: 0.85,
+  studio: 0.58,
+});
+
 function freezeVec4(value) {
   return Object.freeze([value[0], value[1], value[2], value[3] ?? 1]);
+}
+
+function scaleVec4(value, scale) {
+  return [
+    value[0] * scale,
+    value[1] * scale,
+    value[2] * scale,
+    value[3] ?? 1,
+  ];
 }
 
 function normalizeVector3(value, fallback) {
@@ -377,6 +409,27 @@ function normalizeEnvironmentPortals(value) {
   return Object.freeze(value.map(normalizeEnvironmentPortal));
 }
 
+function normalizeEnvironmentMap(value) {
+  if (value == null) {
+    return null;
+  }
+  if (!value || typeof value !== "object") {
+    throw new Error("environmentMap must be an object when provided.");
+  }
+  return Object.freeze({
+    ...value,
+    id: typeof value.id === "string" && value.id.length > 0
+      ? value.id
+      : "environment-map",
+    projection: typeof value.projection === "string" && value.projection.length > 0
+      ? value.projection
+      : "equirectangular",
+    intensity: readPositiveFinite(value.intensity ?? value.radianceScale, 1),
+    rotationRadians: readFinite(value.rotationRadians ?? value.rotation, 0),
+    ambientStrength: Math.max(0, readFinite(value.ambientStrength, 0.32)),
+  });
+}
+
 function freezeLightSourceSpec(source) {
   return Object.freeze({
     ...source,
@@ -391,15 +444,30 @@ function freezeLightSourceSpec(source) {
 }
 
 function defineEnvironmentPreset(spec) {
+  const scene = spec.scene ?? "studio";
+  const timeOfDay = spec.timeOfDay ?? "midday";
+  const ambientScale = Math.max(
+    0,
+    readFinite(spec.ambientScale, environmentPresetAmbientScales[scene] ?? 1)
+  );
+  const defaultSunlitBaseline =
+    (environmentSunlitBaselineByTimeOfDay[timeOfDay] ??
+      environmentSunlitBaselineByTimeOfDay.midday) *
+    (environmentSunlitBaselineSceneScales[scene] ?? 0.58);
+  const sunlitBaseline = Math.max(
+    0,
+    readFinite(spec.sunlitBaseline, defaultSunlitBaseline)
+  );
   return Object.freeze({
     ...spec,
-    scene: spec.scene ?? "studio",
-    timeOfDay: spec.timeOfDay ?? "midday",
+    scene,
+    timeOfDay,
     horizonColor: freezeVec4(spec.horizonColor),
     zenithColor: freezeVec4(spec.zenithColor),
     sunDirection: Object.freeze(normalizeVector3(spec.sunDirection, [0, 1, 0])),
     sunColor: freezeVec4(spec.sunColor),
-    ambientColor: freezeVec4(spec.ambientColor),
+    ambientColor: freezeVec4(scaleVec4(spec.ambientColor, ambientScale)),
+    sunlitBaseline,
     environmentLightSources: Object.freeze(
       (spec.environmentLightSources ?? []).map(freezeLightSourceSpec)
     ),
@@ -952,6 +1020,9 @@ export function createEnvironmentLightingConfig(options = {}) {
   const environmentPortals = normalizeEnvironmentPortals(
     options.environmentPortals ?? options.portals
   );
+  const environmentMap = normalizeEnvironmentMap(
+    options.environmentMap ?? options.hdri ?? preset.environmentMap
+  );
   const environmentPortalMode = normalizeEnvironmentPortalMode(
     options.environmentPortalMode ?? options.portalMode,
     environmentPortals.length > 0
@@ -975,8 +1046,13 @@ export function createEnvironmentLightingConfig(options = {}) {
     ),
     sunColor: readColor(options.sunColor, preset.sunColor),
     ambientColor: readColor(options.ambientColor, preset.ambientColor),
+    sunlitBaseline: Math.max(
+      0,
+      readFinite(options.sunlitBaseline ?? options.daylightBaseline, preset.sunlitBaseline)
+    ),
     environmentPortalMode,
     environmentPortals,
+    environmentMap,
   };
   const environmentLightSources = normalizeEnvironmentLightSources(
     options.environmentLightSources ?? options.lightSources,
@@ -1005,8 +1081,10 @@ export function createEnvironmentLightingConfig(options = {}) {
     wavefront: Object.freeze({
       environmentColor,
       ambientColor: config.ambientColor,
+      sunlitBaseline: config.sunlitBaseline,
       environmentPortalMode: config.environmentPortalMode,
       environmentPortals: config.environmentPortals,
+      environmentMap: config.environmentMap,
       environmentLightSources: config.environmentLightSources,
       lightSources: config.environmentLightSources,
       dominantLightSource,
@@ -1019,8 +1097,10 @@ export function createEnvironmentLightingConfig(options = {}) {
         intensity: config.environmentIntensity,
         mode: config.environmentMode,
         exposure: config.exposure,
+        sunlitBaseline: config.sunlitBaseline,
         environmentPortalMode: config.environmentPortalMode,
         environmentPortalCount: config.environmentPortals.length,
+        environmentMap: config.environmentMap,
         environmentLightSources: config.environmentLightSources,
         environmentLightSourceCount: config.environmentLightSources.length,
         dominantLightSource,
@@ -1035,8 +1115,10 @@ export function createWavefrontEnvironmentLightingOptions(options = {}) {
   return Object.freeze({
     environmentColor: config.wavefront.environmentColor,
     ambientColor: config.wavefront.ambientColor,
+    sunlitBaseline: config.wavefront.sunlitBaseline,
     environmentPortalMode: config.wavefront.environmentPortalMode,
     environmentPortals: config.wavefront.environmentPortals,
+    environmentMap: config.wavefront.environmentMap,
     environmentLightSources: config.wavefront.environmentLightSources,
     lightSources: config.wavefront.environmentLightSources,
     dominantLightSource: config.wavefront.dominantLightSource,

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -51,6 +51,14 @@ function urlToPath(url) {
   return fileURLToPath(url);
 }
 
+function roundColor(value) {
+  return value.map((component) => Number(component.toFixed(4)));
+}
+
+function luminance(value) {
+  return value[0] * 0.2126 + value[1] * 0.7152 + value[2] * 0.0722;
+}
+
 async function importLightingModuleWithBase(metaUrl, querySuffix) {
   const previous = globalThis.__IMPORT_META_URL__;
   globalThis.__IMPORT_META_URL__ = metaUrl;
@@ -143,6 +151,12 @@ test("environment presets cover outdoor, interior, and underground time-of-day v
       assert.equal(config.environmentMissLighting.sourceId, config.dominantLightSource.id);
       assert.ok(config.environmentMissLighting.luminance > 0);
       assert.ok(config.environmentColor.slice(0, 3).every((component) => component > 0));
+      assert.ok(config.sunlitBaseline > 0);
+      assert.equal(config.wavefront.sunlitBaseline, config.sunlitBaseline);
+      assert.equal(
+        config.wavefront.environmentLighting.sunlitBaseline,
+        config.sunlitBaseline
+      );
       assert.ok(
         config.environmentLightSources.every((source) =>
           source.radiance.slice(0, 3).every((component) => component >= 0)
@@ -154,6 +168,46 @@ test("environment presets cover outdoor, interior, and underground time-of-day v
       );
     }
   }
+});
+
+test("environment scene presets use restrained ambient residuals", () => {
+  const field = createEnvironmentLightingConfig({ preset: "grass-field-midday" });
+  const warehouse = createEnvironmentLightingConfig({ preset: "warehouse-midday" });
+  const studio = createEnvironmentLightingConfig({ preset: "product-studio" });
+  const override = createEnvironmentLightingConfig({
+    preset: "forest-midday",
+    ambientColor: [0.08, 0.09, 0.1, 1],
+  });
+
+  assert.deepEqual(roundColor(field.ambientColor), [0.0374, 0.0484, 0.0312, 1]);
+  assert.deepEqual(roundColor(warehouse.ambientColor), [0.0279, 0.0295, 0.0312, 1]);
+  assert.ok(luminance(field.ambientColor) < luminance([0.048, 0.062, 0.04, 1]));
+  assert.ok(luminance(warehouse.ambientColor) < luminance([0.034, 0.036, 0.038, 1]));
+  assert.deepEqual(studio.ambientColor, [0.024, 0.027, 0.03, 1]);
+  assert.deepEqual(override.ambientColor, [0.08, 0.09, 0.1, 1]);
+});
+
+test("environment presets expose time-of-day sunlit baselines", () => {
+  const fieldDawn = createEnvironmentLightingConfig({ preset: "grass-field-dawn" });
+  const fieldMidday = createEnvironmentLightingConfig({ preset: "grass-field-midday" });
+  const fieldDusk = createEnvironmentLightingConfig({ preset: "grass-field-dusk" });
+  const fieldNight = createEnvironmentLightingConfig({ preset: "grass-field-night" });
+  const forestMidday = createEnvironmentLightingConfig({ preset: "forest-midday" });
+  const warehouseMidday = createEnvironmentLightingConfig({ preset: "warehouse-midday" });
+  const cavernMidday = createEnvironmentLightingConfig({ preset: "cavern-midday" });
+  const override = createEnvironmentLightingConfig({
+    preset: "cavern-night",
+    sunlitBaseline: 0.21,
+  });
+
+  assert.ok(fieldMidday.sunlitBaseline > fieldDawn.sunlitBaseline);
+  assert.ok(fieldDawn.sunlitBaseline > fieldDusk.sunlitBaseline);
+  assert.ok(fieldDusk.sunlitBaseline > fieldNight.sunlitBaseline);
+  assert.ok(forestMidday.sunlitBaseline < fieldMidday.sunlitBaseline);
+  assert.ok(warehouseMidday.sunlitBaseline < forestMidday.sunlitBaseline);
+  assert.ok(cavernMidday.sunlitBaseline < warehouseMidday.sunlitBaseline);
+  assert.equal(override.sunlitBaseline, 0.21);
+  assert.equal(override.wavefront.environmentLighting.sunlitBaseline, 0.21);
 });
 
 test("environment preset resolution accepts scene and time-of-day aliases", () => {
@@ -240,8 +294,18 @@ test("environment lighting config normalizes window portals for environment ligh
 });
 
 test("wavefront environment lighting options provide renderer-ready fields", () => {
+  const environmentMap = {
+    id: "studio-hdri",
+    projection: "equirectangular",
+    width: 4,
+    height: 2,
+    intensity: 1.6,
+    rotationRadians: 0.5,
+    ambientStrength: 0.42,
+  };
   const options = createWavefrontEnvironmentLightingOptions({
     preset: "moonlit-harbor",
+    environmentMap,
     environmentPortalMode: "guide",
     environmentPortals: [
       {
@@ -260,6 +324,14 @@ test("wavefront environment lighting options provide renderer-ready fields", () 
   assert.equal(options.environmentPortals.length, 1);
   assert.equal(options.environmentPortals[0].width, 1);
   assert.equal(options.environmentPortals[0].height, 0.5);
+  assert.equal(options.environmentMap.id, "studio-hdri");
+  assert.equal(options.environmentMap.projection, "equirectangular");
+  assert.equal(options.environmentMap.intensity, 1.6);
+  assert.equal(options.environmentMap.rotationRadians, 0.5);
+  assert.equal(options.environmentMap.ambientStrength, 0.42);
+  assert.equal(options.sunlitBaseline, options.lightingEnvironment.sunlitBaseline);
+  assert.equal(options.environmentLighting.sunlitBaseline, options.sunlitBaseline);
+  assert.deepEqual(options.environmentLighting.environmentMap, options.environmentMap);
   assert.equal(options.environmentLighting.horizonColor.length, 4);
   assert.equal(options.environmentLighting.zenithColor.length, 4);
   assert.equal(options.environmentLighting.sunColor.length, 4);


### PR DESCRIPTION
## Summary
- expose scene/time-of-day sunlitBaseline in environment presets
- forward the baseline through wavefront lighting options
- preserve restrained ambient residuals and HDRI/environmentMap passthrough

## Local validation
- npm run typecheck
- npm run build
- npm run lint
- npm run test:unit -- tests/package.test.js
- npm run test:coverage
- npm run audit:npm
- git diff --check