### PR TITLE
fix: make lighting CD respect protected main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,11 +19,15 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: write
   id-token: write # for npm provenance (requires Node 18+ and npm >=9)
   attestations: write
+  pull-requests: write
 
 env:
+  FALLBACK_RUNNER_LABEL: ubuntu-latest
+  SELF_HOSTED_RUNNER_LABELS: '["self-hosted","Linux","X64"]'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
@@ -40,7 +44,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Bump version & decide publish flags
+      - name: Prepare release metadata
         id: pkg
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -51,50 +55,69 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Decide bump command
-          BUMP_CMD=""
-          case "${BUMP:-patch}" in
-            major|minor|patch)
-              if [ -n "${PREID:-}" ]; then
-                # Convert to pre* if preid provided
-                case "${BUMP}" in
-                  major) BUMP_CMD="npm version premajor --preid ${PREID} -m 'chore: release v%s [skip ci]'" ;;
-                  minor) BUMP_CMD="npm version preminor --preid ${PREID} -m 'chore: release v%s [skip ci]'" ;;
-                  patch) BUMP_CMD="npm version prepatch --preid ${PREID} -m 'chore: release v%s [skip ci]'" ;;
-                esac
-              else
-                BUMP_CMD="npm version ${BUMP} -m 'chore: release v%s [skip ci]'"
-              fi
-              ;;
-            none)
-              # No version bump; use existing version
-              BUMP_CMD="echo"
-              ;;
-            *)
-              echo "Unknown bump type: ${BUMP}" >&2
-              exit 1
-              ;;
-          esac
+          CURRENT_VER=$(node -p "require('./package.json').version")
+          NAME=$(node -p "require('./package.json').name")
 
           if [ "${BUMP}" = "none" ]; then
-            CURRENT_VER=$(node -p "require('./package.json').version")
             NEW_VER="v${CURRENT_VER}"
+            # The later metadata step creates and pushes this tag before gh release create --verify-tag.
           else
-            # shellcheck disable=SC2086
-            NEW_VER=$(sh -lc "$BUMP_CMD")
+            case "${BUMP:-patch}" in
+              major|minor|patch) ;;
+              *)
+                echo "Unknown bump type: ${BUMP}" >&2
+                exit 1
+                ;;
+            esac
+
+            REGISTRY_VER=$(npm view "$NAME" version 2>/dev/null || true)
+            TARGET_VER=$(node -e '
+          const [localVersion, registryVersion, bump, preid] = process.argv.slice(1);
+          const clean = (value) => String(value || "").replace(/^v/, "").trim();
+          const parse = (value) => {
+            const [core] = clean(value).split("-");
+            const parts = core.split(".").map((part) => Number(part));
+            if (parts.length !== 3 || parts.some((part) => !Number.isInteger(part) || part < 0)) {
+              throw new Error(`Invalid semver value: ${value}`);
+            }
+            return parts;
+          };
+          const compare = (left, right) => {
+            for (let index = 0; index < 3; index += 1) {
+              const diff = left[index] - right[index];
+              if (diff !== 0) return diff;
+            }
+            return 0;
+          };
+
+          const local = parse(localVersion);
+          const registry = registryVersion ? parse(registryVersion) : local;
+          const base = compare(registry, local) > 0 ? registry : local;
+          let next;
+          switch (bump) {
+            case "major":
+              next = [base[0] + 1, 0, 0];
+              break;
+            case "minor":
+              next = [base[0], base[1] + 1, 0];
+              break;
+            case "patch":
+              next = [base[0], base[1], base[2] + 1];
+              break;
+            default:
+              throw new Error(`Unknown bump type: ${bump}`);
+          }
+
+          let version = next.join(".");
+          if (preid) {
+            version = `${version}-${preid}.0`;
+          }
+          process.stdout.write(version);
+          ' "$CURRENT_VER" "$REGISTRY_VER" "$BUMP" "${PREID:-}")
+            NEW_VER=$(npm version "$TARGET_VER" --no-git-tag-version --allow-same-version)
           fi
 
           echo "New version: $NEW_VER"
-          if [ "${BUMP}" = "none" ]; then
-            if git ls-remote --exit-code --tags origin "refs/tags/${NEW_VER}" >/dev/null 2>&1; then
-              echo "Tag ${NEW_VER} already exists on origin."
-            else
-              git tag -a "$NEW_VER" -m "chore: release ${NEW_VER}"
-              git push origin "refs/tags/${NEW_VER}"
-            fi
-          else
-            git push --follow-tags
-          fi
 
           # Expose tag (vX.Y.Z) and version (X.Y.Z) for later steps
           VER_NO_V=${NEW_VER#v}
@@ -146,8 +169,6 @@ jobs:
           verbose: true
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           FILE="CHANGELOG.md"
           if [ ! -f "$FILE" ]; then
@@ -225,9 +246,44 @@ jobs:
             echo "[${VERSION}]: https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${VERSION}" >> "$FILE"
           fi
 
-          git add "$FILE"
-          git commit -m "docs(changelog): release v${VERSION}"
-          git push
+      - name: Commit release metadata and tag
+        env:
+          TAG: ${{ steps.pkg.outputs.tag }}
+          VERSION: ${{ steps.pkg.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --tags origin
+          RELEASE_BRANCH="automation/release-${TAG#v}-${GITHUB_RUN_ID}"
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists. Immutable releases must use a new version."
+            exit 1
+          fi
+
+          git add package.json package-lock.json CHANGELOG.md
+          METADATA_CHANGED=0
+          if git diff --cached --quiet; then
+            echo "No release metadata changes to commit for ${TAG}; tagging current HEAD."
+          else
+            git commit -m "chore: release ${TAG} [skip ci]"
+            METADATA_CHANGED=1
+          fi
+
+          git tag "${TAG}"
+          if [ "$METADATA_CHANGED" = "1" ]; then
+            git push origin "HEAD:${RELEASE_BRANCH}" "${TAG}"
+            if ! gh pr create \
+              --base "${GITHUB_REF_NAME:-main}" \
+              --head "${RELEASE_BRANCH}" \
+              --title "docs(changelog): release ${TAG}" \
+              --body "Generated by the CD workflow for ${TAG}. The package publish uses the tagged release metadata commit; this PR persists package.json, package-lock.json, and CHANGELOG.md on the protected main branch."; then
+              echo "::warning::Unable to create release metadata PR from GitHub Actions. Branch ${RELEASE_BRANCH} and tag ${TAG} were pushed; publication will continue."
+            fi
+          else
+            git push origin "${TAG}"
+          fi
 
       - name: Create GitHub Release draft (immutable-safe)
         env:


### PR DESCRIPTION
## Summary
- align gpu-lighting CD release metadata handling with gpu-renderer
- avoid direct pushes to protected main from the production publish workflow
- persist package/changelog release metadata through an automation PR branch while publishing from the tagged release metadata commit

## Validation
- git diff --check

This fixes the failed CD run https://github.com/Plasius-LTD/gpu-lighting/actions/runs/27339307934.