### PR TITLE
feat: add wavefront lighting contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,25 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
     integration for the published realtime and reference profiles.
   - Added concrete HDRI/IBL WGSL kernels for `irradianceConvolution`,
     `specularPrefilter`, and `brdfLut`.
+  - Added a renderer-aligned `wavefront` lighting technique with concrete
+    WGSL jobs for terminal radiance accumulation and continuation scattering.
+  - Added `createWavefrontLightingPlan()`,
+    `evaluateWavefrontTerminalRadiance()`, and
+    `evaluateWavefrontContinuationEvent()` so downstream packages and tests can
+    validate emissive-hit, environment-hit, miss-darkening, reflection,
+    refraction, and transparency behavior without reimplementing the contract.
 
 - **Changed**
   - README now documents the delivered volumetrics and HDRI kernel scope with
     technique-level descriptions instead of leaving those exported jobs implied.
+  - Eames capture helpers now resolve workspace roots correctly from both
+    ordinary repo checkouts and `git worktree` paths.
 
 - **Fixed**
   - Package tests now fail if any exported `hybrid`, `volumetrics`, or `hdri`
     job regresses to placeholder text or an empty/no-op `process_job` body.
+  - Eames asset-path and capture-bridge tests are now worktree-safe instead of
+    assuming the package always lives under a literal `/gpu-lighting/` path.
 
 ## [0.2.2] - 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,43 @@ const profileManifest = getLightingProfileWorkerManifest("realtime");
 console.log(profileManifest.jobs.map((job) => job.worker.jobType));
 ```
 
+## Wavefront Lighting Contracts
+
+`@plasius/gpu-lighting` now also publishes a renderer-aligned `wavefront`
+technique for the first active-ray lighting slice. It keeps the queue layout,
+buffer contract names, and terminal-hit policy aligned with
+`@plasius/gpu-renderer` while owning the lighting-specific WGSL for terminal
+radiance accumulation and continuation scattering.
+
+```js
+import {
+  createWavefrontLightingPlan,
+  evaluateWavefrontTerminalRadiance,
+  loadLightingTechniqueWorkerBundle,
+} from "@plasius/gpu-lighting";
+
+const plan = createWavefrontLightingPlan({
+  maxDepth: 6,
+  queueCapacity: 4096,
+  explicitLightSampling: true,
+});
+
+const bundle = await loadLightingTechniqueWorkerBundle("wavefront");
+const emissive = evaluateWavefrontTerminalRadiance({
+  hitType: "emissive",
+  throughput: [0.5, 0.5, 0.5],
+  emission: [8, 6, 4],
+});
+
+console.log(plan.requiredRendererPassOrder);
+console.log(bundle.jobs.map((job) => job.label));
+console.log(emissive.radiance);
+```
+
+This slice keeps emissive hits, environment hits, and environment-miss dark
+fallbacks on the lighting package surface without reintroducing a depth-first
+shader dependency into the renderer-owned wavefront queue model.
+
 ## Distance-Banded Lighting
 
 ```js

--- a/docs/adrs/adr-0008: Renderer-Aligned Wavefront Lighting Jobs.md
+++ b/docs/adrs/adr-0008: Renderer-Aligned Wavefront Lighting Jobs.md
@@ -1,0 +1,62 @@
+# ADR-0008: Renderer-Aligned Wavefront Lighting Jobs
+
+## Status
+
+Accepted
+
+## Context
+
+`@plasius/gpu-renderer` now owns the public wavefront queue layout, hit/surface
+records, and terminal-hit policy for active-ray path tracing. The lighting
+package still only exposed the older depth-first `pathtracer` WGSL entry points,
+which meant downstream consumers had no lighting-owned shader tranche for the
+renderer's breadth-first wavefront path.
+
+Story `plasius-ltd-site#1039` requires the first lighting slice where emissive
+hits and environment misses terminate correctly through wavefront GPU jobs
+without reintroducing a depth-first correctness dependency.
+
+## Decision
+
+`@plasius/gpu-lighting` will add a public `wavefront` technique that is aligned
+to the renderer-owned contracts rather than inventing a second queue model.
+
+This slice publishes:
+
+- the same queue-pair strategy and buffer contract names used by
+  `@plasius/gpu-renderer`
+- a lighting-owned plan helper, `createWavefrontLightingPlan()`, that makes the
+  required renderer pass order and lighting-owned passes explicit
+- concrete WGSL jobs for:
+  - `accumulateTerminalRadiance`
+  - `scatterContinuations`
+- JS reference helpers for deterministic emissive/environment termination and
+  continuation-event validation
+
+The existing depth-first `pathtracer` technique remains available as a
+reference-mode baseline. The new wavefront technique is an additive public
+surface for renderer integration and validation.
+
+## Consequences
+
+- Positive: `gpu-lighting` now owns the first renderer-consumable wavefront
+  lighting tranche instead of forcing downstream packages to reuse
+  depth-first-only WGSL.
+- Positive: contract drift between `gpu-renderer` and `gpu-lighting` becomes
+  testable via shared queue/buffer/termination expectations.
+- Positive: deterministic CPU-side helpers make emissive-hit, environment-hit,
+  miss-darkening, and continuation behavior testable without a WebGPU runtime.
+- Neutral: this slice only covers terminal radiance and continuation scattering;
+  it does not yet own explicit light sampling, MIS weighting, or medium-heavy
+  transport orchestration beyond the published hooks.
+- Negative: the package now carries both depth-first and wavefront path-tracing
+  surfaces, so documentation and tests must keep the intended roles clear.
+
+## Follow-On Work
+
+- Extend the wavefront slice with explicit light sampling and MIS once the
+  renderer-owned queue orchestration is ready for that path.
+- Add richer medium-aware continuation and attenuation once the lighting slice
+  consumes fuller medium contracts.
+- Promote the wavefront technique into a broader lighting profile once the
+  remaining wavefront child stories are complete.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -7,3 +7,4 @@
 - [Architectural Decision Record (ADR)](./adr-0005:%20Worker-First%20Lighting%20Governance%20Manifest.md)
 - [Architectural Decision Record (ADR)](./adr-0006:%20Distance-Banded%20Lighting%20and%20Shadow%20Sources.md)
 - [Architectural Decision Record (ADR)](./adr-0007:%20Reference-First%20Adaptive%20Lighting%20Profile%20Ladder.md)
+- [Architectural Decision Record (ADR)](./adr-0008:%20Renderer-Aligned%20Wavefront%20Lighting%20Jobs.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@plasius/gpu-renderer": "^0.2.7",
         "@playwright/test": "^1.60.0",
         "c8": "^11.0.0",
         "eslint": "^10.3.0",
@@ -888,6 +889,30 @@
         "react": "^19"
       }
     },
+    "node_modules/@plasius/gpu-renderer": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-renderer/-/gpu-renderer-0.2.7.tgz",
+      "integrity": "sha512-9yTJncgzZarDxjqLMLlhDPZkER5fCP9uB0KkTLdHzIyDJC8iplv7tfIpkR+tuHT5X0opgk3QgZt30UGYYcVj1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/c/plasiusltd/membership"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Plasius-LTD"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@plasius/gpu-shared": "^0.1.11",
+        "@plasius/gpu-xr": "^0.1.11"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
     "node_modules/@plasius/gpu-shared": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@plasius/gpu-shared/-/gpu-shared-0.1.11.tgz",
@@ -932,6 +957,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@plasius/gpu-lock-free-queue": "^0.2.18",
+        "@plasius/gpu-shared": "^0.1.9"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@plasius/gpu-xr": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-xr/-/gpu-xr-0.1.13.tgz",
+      "integrity": "sha512-TyOKSwVbrW6OqnbPLILzYZqfGq3L+s4Fr0D460mjZ/FWKQJudHPNG+GaTN23fBSbowl7s+30TUCk0xngi27HMA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/c/plasiusltd/membership"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Plasius-LTD"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
         "@plasius/gpu-shared": "^0.1.9"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@plasius/gpu-renderer": "^0.2.7",
     "@playwright/test": "^1.60.0",
     "c8": "^11.0.0",
     "eslint": "^10.3.0",

--- a/scripts/eames-environments/capture-bridge-server.mjs
+++ b/scripts/eames-environments/capture-bridge-server.mjs
@@ -1,11 +1,9 @@
 import fs from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { decodePngDataUrl } from "./capture-runtime.mjs";
+import { decodePngDataUrl, resolveCaptureWorkspaceRoot } from "./capture-runtime.mjs";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const workspaceRoot = path.resolve(__dirname, "../../..");
+const workspaceRoot = resolveCaptureWorkspaceRoot();
 const captureOutputRoot = path.resolve(workspaceRoot, "output/playwright/eames-environments");
 const port = Number(process.argv[2] ?? 8001);
 const trustedLoopbackHostnames = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);

--- a/scripts/eames-environments/capture-runtime.mjs
+++ b/scripts/eames-environments/capture-runtime.mjs
@@ -6,8 +6,15 @@ import { chromium } from "playwright";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(__dirname, "../..");
-const workspaceRoot = path.resolve(packageRoot, "..");
-const repoRoot = path.resolve(__dirname, "../../..");
+function resolveWorkspaceRootFromPackageRoot(currentPackageRoot) {
+  const directParent = path.resolve(currentPackageRoot, "..");
+  if (path.basename(directParent) === ".worktrees") {
+    return path.resolve(directParent, "..");
+  }
+  return directParent;
+}
+const workspaceRoot = resolveWorkspaceRootFromPackageRoot(packageRoot);
+const repoRoot = workspaceRoot;
 const defaultCaptureArtifactDirectory = path.join(
   repoRoot,
   "output/playwright/eames-environments"

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,15 @@ const techniqueSpecs = {
       denoise: "denoise.job.wgsl",
     },
   },
+  wavefront: {
+    description:
+      "Renderer-aligned wavefront lighting jobs for terminal radiance and continuation scattering.",
+    prelude: "prelude.wgsl",
+    jobs: {
+      accumulateTerminalRadiance: "accumulate-terminal-radiance.job.wgsl",
+      scatterContinuations: "scatter-continuations.job.wgsl",
+    },
+  },
   volumetrics: {
     description:
       "Froxel volumetric lighting for fog, shafts, and participating media shadows.",
@@ -1128,6 +1137,421 @@ export function createWavefrontEnvironmentLightingOptions(options = {}) {
   });
 }
 
+export const lightingWavefrontSchemaVersion = 1;
+export const lightingWavefrontQueuePairStrategy = "ping-pong-active-next";
+export const lightingWavefrontHitTypes = Object.freeze([
+  "surface",
+  "emissive",
+  "environment",
+  "transparent",
+  "miss",
+]);
+export const lightingWavefrontTerminalHitTypes = Object.freeze([
+  "emissive",
+  "environment",
+  "miss",
+]);
+export const lightingWavefrontContinuationHitTypes = Object.freeze([
+  "surface",
+  "transparent",
+]);
+export const lightingWavefrontPassOrder = Object.freeze([
+  "accumulateTerminalRadiance",
+  "scatterContinuations",
+]);
+export const lightingRequiredRendererWavefrontPassOrder = Object.freeze([
+  "generatePrimaryRays",
+  "intersectActiveQueue",
+  "resolveSurfaceRecords",
+  "accumulateTerminalRadiance",
+  "scatterContinuations",
+  "compactAndSwapQueues",
+]);
+
+function createLightingWavefrontField(name, type, description) {
+  return Object.freeze({
+    name,
+    type,
+    description,
+  });
+}
+
+function createLightingWavefrontRecordContract(recordName, fields) {
+  return Object.freeze({
+    schemaVersion: lightingWavefrontSchemaVersion,
+    recordName,
+    fields: Object.freeze(fields),
+  });
+}
+
+export const lightingWavefrontBufferContracts = Object.freeze({
+  ray: createLightingWavefrontRecordContract(
+    "RayRecord",
+    [
+      createLightingWavefrontField("rayId", "u32", "Stable ray identifier."),
+      createLightingWavefrontField("parentRayId", "u32", "Parent ray identifier."),
+      createLightingWavefrontField("sourcePixelId", "u32", "Source pixel/sample owner."),
+      createLightingWavefrontField("sampleId", "u32", "Per-pixel sample slot."),
+      createLightingWavefrontField("bounce", "u32", "Current bounce depth."),
+      createLightingWavefrontField("origin", "vec3<f32>", "Ray origin."),
+      createLightingWavefrontField("direction", "vec3<f32>", "Normalized ray direction."),
+      createLightingWavefrontField("throughput", "vec3<f32>", "Accumulated path throughput."),
+      createLightingWavefrontField("mediumRefId", "u32", "Current medium reference."),
+      createLightingWavefrontField("flags", "u32", "Renderer-owned ray flags."),
+    ]
+  ),
+  hit: createLightingWavefrontRecordContract(
+    "HitRecord",
+    [
+      createLightingWavefrontField("rayId", "u32", "Stable ray identifier."),
+      createLightingWavefrontField("sourcePixelId", "u32", "Source pixel/sample owner."),
+      createLightingWavefrontField("hitType", "u32", "Surface, emissive, environment, transparent, or miss."),
+      createLightingWavefrontField("distance", "f32", "Nearest-hit distance."),
+      createLightingWavefrontField("entityId", "u32", "Owning entity identifier."),
+      createLightingWavefrontField("instanceId", "u32", "Owning instance identifier."),
+      createLightingWavefrontField("primitiveId", "u32", "Primitive identifier."),
+      createLightingWavefrontField("materialId", "u32", "Resolved material identifier."),
+      createLightingWavefrontField("barycentrics", "vec3<f32>", "Triangle barycentrics."),
+      createLightingWavefrontField("uv", "vec2<f32>", "Resolved UV coordinates."),
+      createLightingWavefrontField("geometricNormal", "vec3<f32>", "Geometric surface normal."),
+      createLightingWavefrontField("shadingNormal", "vec3<f32>", "Interpolated shading normal."),
+      createLightingWavefrontField("frontFace", "u32", "Front-face classification."),
+    ]
+  ),
+  surface: createLightingWavefrontRecordContract(
+    "SurfaceRecord",
+    [
+      createLightingWavefrontField("rayId", "u32", "Stable ray identifier."),
+      createLightingWavefrontField("entityId", "u32", "Owning entity identifier."),
+      createLightingWavefrontField("materialRefId", "u32", "Renderer material reference id."),
+      createLightingWavefrontField("mediumRefId", "u32", "Renderer medium reference id."),
+      createLightingWavefrontField("geometricNormal", "vec3<f32>", "Geometric surface normal."),
+      createLightingWavefrontField("shadingNormal", "vec3<f32>", "Interpolated shading normal."),
+      createLightingWavefrontField("uv", "vec2<f32>", "Resolved UV coordinates."),
+      createLightingWavefrontField("tangentFrame", "mat3x3<f32>", "Resolved tangent frame."),
+    ]
+  ),
+  materialReference: createLightingWavefrontRecordContract(
+    "MaterialReferenceRecord",
+    [
+      createLightingWavefrontField("materialRefId", "u32", "Lighting-visible material reference id."),
+      createLightingWavefrontField("materialId", "u32", "Source material identifier."),
+      createLightingWavefrontField("shadingModel", "u32", "Renderer shading-model discriminator."),
+      createLightingWavefrontField("textureSetId", "u32", "Resolved texture-set identifier."),
+      createLightingWavefrontField("flags", "u32", "Renderer material flags."),
+    ]
+  ),
+  mediumReference: createLightingWavefrontRecordContract(
+    "MediumReferenceRecord",
+    [
+      createLightingWavefrontField("mediumRefId", "u32", "Lighting-visible medium reference id."),
+      createLightingWavefrontField("mediumId", "u32", "Source medium identifier."),
+      createLightingWavefrontField("phaseModel", "u32", "Phase-function discriminator."),
+      createLightingWavefrontField("absorption", "vec3<f32>", "Medium absorption coefficients."),
+      createLightingWavefrontField("scattering", "vec3<f32>", "Medium scattering coefficients."),
+    ]
+  ),
+  accumulation: createLightingWavefrontRecordContract(
+    "AccumulationRecord",
+    [
+      createLightingWavefrontField("sourcePixelId", "u32", "Source pixel/sample owner."),
+      createLightingWavefrontField("sampleCount", "u32", "Accumulated sample count."),
+      createLightingWavefrontField("radiance", "vec3<f32>", "Accumulated radiance."),
+      createLightingWavefrontField("throughput", "vec3<f32>", "Last surviving throughput."),
+      createLightingWavefrontField("resetEpoch", "u32", "Renderer accumulation reset epoch."),
+    ]
+  ),
+});
+
+export const lightingWavefrontTerminationPolicy = Object.freeze({
+  terminalHitTypes: lightingWavefrontTerminalHitTypes,
+  continuationHitTypes: lightingWavefrontContinuationHitTypes,
+  emissive: Object.freeze({
+    action: "accumulate-and-stop",
+    contributesRadiance: true,
+  }),
+  environment: Object.freeze({
+    action: "accumulate-and-stop",
+    contributesRadiance: true,
+  }),
+  miss: Object.freeze({
+    action: "accumulate-environment-or-dark-stop",
+    contributesRadiance: true,
+  }),
+});
+
+const defaultWavefrontDarkRadiance = Object.freeze([0.0001, 0.0001, 0.0001]);
+const wavefrontEventKinds = Object.freeze([
+  "diffuse",
+  "reflection",
+  "refraction",
+  "transparency",
+  "terminate",
+]);
+
+function normalizeWavefrontHitType(value) {
+  return lightingWavefrontHitTypes.includes(value) ? value : "surface";
+}
+
+function normalizeWavefrontEventKind(value) {
+  return wavefrontEventKinds.includes(value) ? value : null;
+}
+
+function normalizeVec3(value, fallback = [0, 0, 0]) {
+  if (!Array.isArray(value) || value.length < 3) {
+    return [...fallback];
+  }
+  return [
+    Number.isFinite(value[0]) ? value[0] : fallback[0],
+    Number.isFinite(value[1]) ? value[1] : fallback[1],
+    Number.isFinite(value[2]) ? value[2] : fallback[2],
+  ];
+}
+
+function clampUnit(value, fallback = 0) {
+  return Math.max(0, Math.min(1, readFinite(value, fallback)));
+}
+
+function saturateVec3(value) {
+  return value.map((component) => Math.max(0, component));
+}
+
+function scaleVec3(value, scalar) {
+  return value.map((component) => component * scalar);
+}
+
+function addVec3(left, right) {
+  return left.map((component, index) => component + right[index]);
+}
+
+function multiplyVec3(left, right) {
+  return left.map((component, index) => component * right[index]);
+}
+
+function dotVec3(left, right) {
+  return left[0] * right[0] + left[1] * right[1] + left[2] * right[2];
+}
+
+function lengthVec3(value) {
+  return Math.hypot(value[0], value[1], value[2]);
+}
+
+function normalizeDirection(value, fallback = [0, 1, 0]) {
+  const vector = normalizeVec3(value, fallback);
+  const length = lengthVec3(vector);
+  if (!Number.isFinite(length) || length <= 0.000001) {
+    return [...fallback];
+  }
+  return vector.map((component) => component / length);
+}
+
+function mixVec3(left, right, factor) {
+  return left.map((component, index) =>
+    component * (1 - factor) + right[index] * factor
+  );
+}
+
+function reflectDirection(direction, normal) {
+  const scale = 2 * dotVec3(direction, normal);
+  return normalizeDirection(
+    [
+      direction[0] - scale * normal[0],
+      direction[1] - scale * normal[1],
+      direction[2] - scale * normal[2],
+    ],
+    normal
+  );
+}
+
+function refractDirection(direction, normal, etaRatio) {
+  const cosTheta = Math.min(-dotVec3(direction, normal), 1);
+  const rOutPerp = scaleVec3(addVec3(direction, scaleVec3(normal, cosTheta)), etaRatio);
+  const rOutPerpLengthSquared = dotVec3(rOutPerp, rOutPerp);
+  const parallelFactor = 1 - rOutPerpLengthSquared;
+  if (parallelFactor <= 0) {
+    return null;
+  }
+  const rOutParallel = scaleVec3(normal, -Math.sqrt(parallelFactor));
+  return normalizeDirection(addVec3(rOutPerp, rOutParallel), direction);
+}
+
+export function createWavefrontLightingPlan(options = {}) {
+  const maxDepth = Math.max(1, Math.trunc(readFinite(options.maxDepth, 4)));
+  const queueCapacity = Math.max(
+    1,
+    Math.trunc(readFinite(options.queueCapacity, 4096))
+  );
+  const explicitLightSampling = Boolean(options.explicitLightSampling);
+  const accumulationResetEpoch = Math.max(
+    0,
+    Math.trunc(readFinite(options.accumulationResetEpoch, 0))
+  );
+
+  return Object.freeze({
+    schemaVersion: lightingWavefrontSchemaVersion,
+    maxDepth,
+    queueCapacity,
+    explicitLightSampling,
+    accumulationResetEpoch,
+    queueLayout: Object.freeze({
+      strategy: lightingWavefrontQueuePairStrategy,
+      compactAfterScatter: true,
+      queues: Object.freeze([
+        Object.freeze({ name: "active", role: "current-bounce" }),
+        Object.freeze({ name: "next", role: "next-bounce" }),
+      ]),
+    }),
+    bufferContracts: lightingWavefrontBufferContracts,
+    terminationPolicy: lightingWavefrontTerminationPolicy,
+    requiredRendererPassOrder: lightingRequiredRendererWavefrontPassOrder,
+    lightingPasses: Object.freeze([
+      Object.freeze({
+        key: "accumulateTerminalRadiance",
+        stage: "accumulateTerminalRadiance",
+        reads: Object.freeze([
+          "ray",
+          "hit",
+          "surface",
+          "materialReference",
+          "mediumReference",
+        ]),
+        writes: Object.freeze(["accumulation"]),
+        terminalHitTypes: lightingWavefrontTerminalHitTypes,
+      }),
+      Object.freeze({
+        key: "scatterContinuations",
+        stage: "scatterContinuations",
+        reads: Object.freeze([
+          "ray",
+          "hit",
+          "surface",
+          "materialReference",
+          "mediumReference",
+        ]),
+        writes: Object.freeze(["ray"]),
+        continuationHitTypes: lightingWavefrontContinuationHitTypes,
+        explicitLightSampling,
+      }),
+    ]),
+  });
+}
+
+export function evaluateWavefrontTerminalRadiance(options = {}) {
+  const hitType = normalizeWavefrontHitType(options.hitType);
+  const throughput = saturateVec3(normalizeVec3(options.throughput, [1, 1, 1]));
+  const emission = saturateVec3(normalizeVec3(options.emission, [0, 0, 0]));
+  const environmentRadiance = saturateVec3(
+    normalizeVec3(options.environmentRadiance, [0, 0, 0])
+  );
+  const missRadiance = saturateVec3(
+    normalizeVec3(options.missRadiance, defaultWavefrontDarkRadiance)
+  );
+  const environmentLuminance = colorLuminance(environmentRadiance);
+  let source = "none";
+  let rawRadiance = [0, 0, 0];
+
+  if (hitType === "emissive") {
+    source = "emissive";
+    rawRadiance = emission;
+  } else if (hitType === "environment") {
+    source = "environment";
+    rawRadiance = environmentRadiance;
+  } else if (hitType === "miss") {
+    source = environmentLuminance > 0.000001 ? "environment" : "dark";
+    rawRadiance = environmentLuminance > 0.000001 ? environmentRadiance : missRadiance;
+  }
+
+  const radiance = multiplyVec3(throughput, rawRadiance);
+  const terminated = lightingWavefrontTerminalHitTypes.includes(hitType);
+
+  return Object.freeze({
+    hitType,
+    source,
+    terminated,
+    radiance: Object.freeze(radiance),
+    nearDarkSample:
+      source === "dark" && colorLuminance(radiance) <= colorLuminance(defaultWavefrontDarkRadiance),
+  });
+}
+
+export function evaluateWavefrontContinuationEvent(options = {}) {
+  const hitType = normalizeWavefrontHitType(options.hitType);
+  const bounceIndex = Math.max(0, Math.trunc(readFinite(options.bounceIndex, 0)));
+  const maxDepth = Math.max(1, Math.trunc(readFinite(options.maxDepth, 4)));
+  const throughput = saturateVec3(normalizeVec3(options.throughput, [1, 1, 1]));
+  const albedo = saturateVec3(normalizeVec3(options.albedo, [0.8, 0.8, 0.8]));
+  const transmission = saturateVec3(
+    normalizeVec3(options.transmission, [0, 0, 0])
+  );
+  const shadingNormal = normalizeDirection(options.shadingNormal, [0, 1, 0]);
+  const viewDirection = normalizeDirection(options.viewDirection, [0, 0, 1]);
+  const incomingDirection = normalizeDirection(
+    scaleVec3(viewDirection, -1),
+    [0, 0, -1]
+  );
+  const frontFace = options.frontFace !== false;
+  const orientedNormal = frontFace
+    ? shadingNormal
+    : scaleVec3(shadingNormal, -1);
+  const metalness = clampUnit(options.metalness, 0);
+  const roughness = clampUnit(options.roughness, 0.5);
+  const opacity = clampUnit(options.opacity, 1);
+  const refractiveIndex = Math.max(1, readFinite(options.refractiveIndex ?? options.ior, 1.45));
+  const transmissionStrength = Math.max(...transmission);
+  let eventKind =
+    normalizeWavefrontEventKind(options.eventKind) ??
+    (hitType === "transparent" || opacity < 0.999
+      ? "transparency"
+      : transmissionStrength > 0.001
+        ? "refraction"
+        : metalness >= 0.5 || roughness <= 0.2
+          ? "reflection"
+          : "diffuse");
+
+  let nextDirection = incomingDirection;
+  let attenuation;
+
+  if (!lightingWavefrontContinuationHitTypes.includes(hitType) || bounceIndex >= maxDepth - 1) {
+    eventKind = "terminate";
+    attenuation = [0, 0, 0];
+  } else if (eventKind === "reflection") {
+    nextDirection = reflectDirection(incomingDirection, orientedNormal);
+    attenuation = mixVec3([0.04, 0.04, 0.04], albedo, metalness);
+  } else if (eventKind === "refraction") {
+    const etaRatio = frontFace ? 1 / refractiveIndex : refractiveIndex;
+    nextDirection =
+      refractDirection(incomingDirection, orientedNormal, etaRatio) ??
+      reflectDirection(incomingDirection, orientedNormal);
+    attenuation = transmissionStrength > 0.001 ? transmission : [1, 1, 1];
+  } else if (eventKind === "transparency") {
+    nextDirection = incomingDirection;
+    const transparencyWeight = Math.max(1 - opacity, transmissionStrength, 0.05);
+    attenuation = transmissionStrength > 0.001
+      ? transmission
+      : [transparencyWeight, transparencyWeight, transparencyWeight];
+  } else {
+    nextDirection = normalizeDirection(
+      addVec3(orientedNormal, albedo.map((component) => component - 0.5)),
+      orientedNormal
+    );
+    attenuation = scaleVec3(albedo, Math.max(0.05, 1 - metalness));
+  }
+
+  const nextThroughput = multiplyVec3(throughput, saturateVec3(attenuation));
+  const continueTracing =
+    eventKind !== "terminate" && colorLuminance(nextThroughput) > 0.0001;
+
+  return Object.freeze({
+    hitType,
+    eventKind,
+    continueTracing,
+    nextDirection: Object.freeze(nextDirection),
+    attenuation: Object.freeze(saturateVec3(attenuation)),
+    nextThroughput: Object.freeze(nextThroughput),
+    explicitLightSamplingEnabled: Boolean(options.explicitLightSampling),
+  });
+}
+
 const lightingImportanceLevels = Object.freeze([
   "low",
   "medium",
@@ -1725,6 +2149,91 @@ const lightingWorkerSpecPresets = {
       },
     },
   },
+  wavefront: {
+    suggestedAllocationIds: [
+      "lighting.wavefront.active-queue",
+      "lighting.wavefront.next-queue",
+      "lighting.wavefront.accumulation",
+    ],
+    jobs: {
+      accumulateTerminalRadiance: {
+        domain: "lighting",
+        importance: "critical",
+        levels: buildWorkerBudgetLevels(
+          "lighting.wavefront.accumulateTerminalRadiance",
+          lightingWorkerQueueClass,
+          {
+            low: {
+              estimatedCostMs: 0.7,
+              maxDispatchesPerFrame: 1,
+              maxJobsPerDispatch: 32,
+              cadenceDivisor: 2,
+              workgroupScale: 0.5,
+              maxQueueDepth: 96,
+            },
+            medium: {
+              estimatedCostMs: 1.2,
+              maxDispatchesPerFrame: 1,
+              maxJobsPerDispatch: 64,
+              cadenceDivisor: 1,
+              workgroupScale: 0.75,
+              maxQueueDepth: 192,
+            },
+            high: {
+              estimatedCostMs: 1.8,
+              maxDispatchesPerFrame: 2,
+              maxJobsPerDispatch: 128,
+              cadenceDivisor: 1,
+              workgroupScale: 1,
+              maxQueueDepth: 256,
+            },
+          }
+        ),
+        suggestedAllocationIds: [
+          "lighting.wavefront.accumulation",
+          "lighting.wavefront.active-queue",
+        ],
+      },
+      scatterContinuations: {
+        domain: "lighting",
+        importance: "critical",
+        levels: buildWorkerBudgetLevels(
+          "lighting.wavefront.scatterContinuations",
+          lightingWorkerQueueClass,
+          {
+            low: {
+              estimatedCostMs: 0.8,
+              maxDispatchesPerFrame: 1,
+              maxJobsPerDispatch: 32,
+              cadenceDivisor: 2,
+              workgroupScale: 0.5,
+              maxQueueDepth: 96,
+            },
+            medium: {
+              estimatedCostMs: 1.4,
+              maxDispatchesPerFrame: 1,
+              maxJobsPerDispatch: 64,
+              cadenceDivisor: 1,
+              workgroupScale: 0.75,
+              maxQueueDepth: 192,
+            },
+            high: {
+              estimatedCostMs: 2.1,
+              maxDispatchesPerFrame: 2,
+              maxJobsPerDispatch: 128,
+              cadenceDivisor: 1,
+              workgroupScale: 1,
+              maxQueueDepth: 256,
+            },
+          }
+        ),
+        suggestedAllocationIds: [
+          "lighting.wavefront.active-queue",
+          "lighting.wavefront.next-queue",
+        ],
+      },
+    },
+  },
   volumetrics: {
     suggestedAllocationIds: [
       "lighting.volumetrics.froxel-grid",
@@ -1935,6 +2444,13 @@ const lightingWorkerDagSpecs = {
     accumulate: { priority: 3, dependencies: ["pathTrace"] },
     denoise: { priority: 2, dependencies: ["accumulate"] },
   },
+  wavefront: {
+    accumulateTerminalRadiance: { priority: 3, dependencies: [] },
+    scatterContinuations: {
+      priority: 2,
+      dependencies: ["accumulateTerminalRadiance"],
+    },
+  },
   volumetrics: {
     volumetricShadow: { priority: 3, dependencies: [] },
     froxelIntegrate: { priority: 2, dependencies: ["volumetricShadow"] },
@@ -1969,6 +2485,16 @@ function resolveLightingQualityDimensions(techniqueName, jobKey) {
       "pathtracer.pathTrace": { rayTracing: 1, lightingSamples: 1 },
       "pathtracer.accumulate": { temporalReuse: 1, updateCadence: 0.4 },
       "pathtracer.denoise": { temporalReuse: 1, shading: 0.4 },
+      "wavefront.accumulateTerminalRadiance": {
+        rayTracing: 1,
+        lightingSamples: 1,
+        temporalReuse: 0.4,
+      },
+      "wavefront.scatterContinuations": {
+        rayTracing: 1,
+        shading: 0.7,
+        updateCadence: 0.5,
+      },
       "volumetrics.froxelIntegrate": {
         lightingSamples: 0.6,
         shading: 0.4,
@@ -2014,6 +2540,15 @@ function resolveLightingImportanceSignals(techniqueName, jobKey) {
       },
       "pathtracer.accumulate": { visible: true },
       "pathtracer.denoise": { visible: true },
+      "wavefront.accumulateTerminalRadiance": {
+        visible: true,
+        shadowSignificance: "high",
+        reflectionSignificance: "high",
+      },
+      "wavefront.scatterContinuations": {
+        visible: true,
+        reflectionSignificance: "high",
+      },
       "volumetrics.froxelIntegrate": { visible: true },
       "volumetrics.volumetricShadow": { visible: true, shadowSignificance: "high" },
       "hdri.irradianceConvolution": { visible: false },

--- a/src/techniques/wavefront/accumulate-terminal-radiance.job.wgsl
+++ b/src/techniques/wavefront/accumulate-terminal-radiance.job.wgsl
@@ -1,0 +1,61 @@
+@group(0) @binding(0) var<uniform> wavefrontLightingParams: WavefrontLightingParams;
+@group(0) @binding(1) var<storage, read> activeQueue: array<RayRecord>;
+@group(0) @binding(2) var<storage, read> hitBuffer: array<HitRecord>;
+@group(0) @binding(3) var<storage, read> surfaceBuffer: array<SurfaceRecord>;
+@group(0) @binding(4) var<storage, read> materialRefBuffer: array<MaterialReferenceRecord>;
+@group(0) @binding(5) var<storage, read> mediumRefBuffer: array<MediumReferenceRecord>;
+@group(0) @binding(6) var<storage, read_write> accumulationBuffer: array<AccumulationRecord>;
+
+fn resolve_emissive_radiance(
+  material: MaterialReferenceRecord,
+  surface: SurfaceRecord
+) -> vec3<f32> {
+  let uv_weight = saturate_scalar(surface.uv.x + surface.uv.y);
+  let emissive_hint = select(0.0, 1.0, (material.flags & 0x1u) != 0u);
+  let base = material_base_albedo(material);
+  return base * (0.5 + uv_weight * 0.5 + emissive_hint * 2.0);
+}
+
+fn accumulate_terminal_sample(
+  ray: RayRecord,
+  hit: HitRecord,
+  surface: SurfaceRecord,
+  material: MaterialReferenceRecord,
+  accumulation_index: u32
+) {
+  let emissive_radiance = resolve_emissive_radiance(material, surface);
+  let terminal_radiance = terminal_radiance_for_hit(hit, ray, emissive_radiance);
+  if (luminance(terminal_radiance) <= LIGHTING_EPSILON) {
+    return;
+  }
+
+  accumulationBuffer[accumulation_index].sourcePixelId = ray.sourcePixelId;
+  accumulationBuffer[accumulation_index].sampleCount =
+    accumulationBuffer[accumulation_index].sampleCount + 1u;
+  accumulationBuffer[accumulation_index].resetEpoch =
+    wavefrontLightingParams.accumulation_reset_epoch;
+  accumulationBuffer[accumulation_index].radiance =
+    accumulationBuffer[accumulation_index].radiance + terminal_radiance;
+  accumulationBuffer[accumulation_index].throughput = ray.throughput;
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn process_job(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  let index = global_id.x;
+  if (index >= wavefrontLightingParams.active_count) {
+    return;
+  }
+
+  let ray = activeQueue[index];
+  let hit = hitBuffer[index];
+  if (!is_terminal_hit_type(hit.hitType)) {
+    return;
+  }
+
+  let surface = surfaceBuffer[index];
+  let material = materialRefBuffer[surface.materialRefId];
+  let _medium = mediumRefBuffer[surface.mediumRefId];
+  let accumulation_index = min(ray.sourcePixelId, wavefrontLightingParams.active_count - 1u);
+
+  accumulate_terminal_sample(ray, hit, surface, material, accumulation_index);
+}

--- a/src/techniques/wavefront/prelude.wgsl
+++ b/src/techniques/wavefront/prelude.wgsl
@@ -1,0 +1,229 @@
+const LIGHTING_WAVEFRONT_SCHEMA_VERSION: u32 = 1u;
+const LIGHTING_WAVEFRONT_QUEUE_PAIR_STRATEGY: u32 = 1u;
+
+const HIT_TYPE_SURFACE: u32 = 0u;
+const HIT_TYPE_EMISSIVE: u32 = 1u;
+const HIT_TYPE_ENVIRONMENT: u32 = 2u;
+const HIT_TYPE_TRANSPARENT: u32 = 3u;
+const HIT_TYPE_MISS: u32 = 4u;
+
+const EVENT_KIND_DIFFUSE: u32 = 0u;
+const EVENT_KIND_REFLECTION: u32 = 1u;
+const EVENT_KIND_REFRACTION: u32 = 2u;
+const EVENT_KIND_TRANSPARENCY: u32 = 3u;
+const EVENT_KIND_TERMINATE: u32 = 4u;
+
+const LIGHTING_EPSILON: f32 = 0.0001;
+const LIGHTING_INV_PI: f32 = 0.3183098861837907;
+
+struct WavefrontLightingParams {
+  active_count: u32,
+  next_queue_capacity: u32,
+  bounce_index: u32,
+  max_depth: u32,
+  enable_explicit_light_sampling: u32,
+  accumulation_reset_epoch: u32,
+  environment_mode: u32,
+  environment_intensity: f32,
+  sunlit_baseline: f32,
+  _padding0: vec3<f32>,
+  environment_color: vec4<f32>,
+  ambient_color: vec4<f32>,
+  environment_miss_radiance: vec4<f32>,
+};
+
+struct RayRecord {
+  rayId: u32,
+  parentRayId: u32,
+  sourcePixelId: u32,
+  sampleId: u32,
+  bounce: u32,
+  origin: vec3<f32>,
+  _padding0: f32,
+  direction: vec3<f32>,
+  _padding1: f32,
+  throughput: vec3<f32>,
+  mediumRefId: u32,
+  flags: u32,
+};
+
+struct HitRecord {
+  rayId: u32,
+  sourcePixelId: u32,
+  hitType: u32,
+  _padding0: u32,
+  distance: f32,
+  entityId: u32,
+  instanceId: u32,
+  primitiveId: u32,
+  materialId: u32,
+  _padding1: vec3<u32>,
+  barycentrics: vec3<f32>,
+  _padding2: f32,
+  uv: vec2<f32>,
+  _padding3: vec2<f32>,
+  geometricNormal: vec3<f32>,
+  _padding4: f32,
+  shadingNormal: vec3<f32>,
+  frontFace: u32,
+};
+
+struct SurfaceRecord {
+  rayId: u32,
+  entityId: u32,
+  materialRefId: u32,
+  mediumRefId: u32,
+  geometricNormal: vec3<f32>,
+  _padding0: f32,
+  shadingNormal: vec3<f32>,
+  _padding1: f32,
+  uv: vec2<f32>,
+  _padding2: vec2<f32>,
+  tangentFrame0: vec3<f32>,
+  _padding3: f32,
+  tangentFrame1: vec3<f32>,
+  _padding4: f32,
+  tangentFrame2: vec3<f32>,
+  _padding5: f32,
+};
+
+struct MaterialReferenceRecord {
+  materialRefId: u32,
+  materialId: u32,
+  shadingModel: u32,
+  textureSetId: u32,
+  flags: u32,
+  _padding0: vec3<u32>,
+};
+
+struct MediumReferenceRecord {
+  mediumRefId: u32,
+  mediumId: u32,
+  phaseModel: u32,
+  _padding0: u32,
+  absorption: vec3<f32>,
+  _padding1: f32,
+  scattering: vec3<f32>,
+  _padding2: f32,
+};
+
+struct AccumulationRecord {
+  sourcePixelId: u32,
+  sampleCount: u32,
+  resetEpoch: u32,
+  _padding0: u32,
+  radiance: vec3<f32>,
+  _padding1: f32,
+  throughput: vec3<f32>,
+  _padding2: f32,
+};
+
+fn luminance(value: vec3<f32>) -> f32 {
+  return dot(value, vec3<f32>(0.2126, 0.7152, 0.0722));
+}
+
+fn saturate_scalar(value: f32) -> f32 {
+  return clamp(value, 0.0, 1.0);
+}
+
+fn saturate_vec3(value: vec3<f32>) -> vec3<f32> {
+  return max(value, vec3<f32>(0.0));
+}
+
+fn safe_normalize(value: vec3<f32>) -> vec3<f32> {
+  if (dot(value, value) <= LIGHTING_EPSILON) {
+    return vec3<f32>(0.0, 1.0, 0.0);
+  }
+  return normalize(value);
+}
+
+fn faceforward_normal(normal: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
+  return select(normal, -normal, dot(normal, direction) > 0.0);
+}
+
+fn is_terminal_hit_type(hit_type: u32) -> bool {
+  return hit_type == HIT_TYPE_EMISSIVE ||
+    hit_type == HIT_TYPE_ENVIRONMENT ||
+    hit_type == HIT_TYPE_MISS;
+}
+
+fn environment_radiance(direction: vec3<f32>) -> vec3<f32> {
+  let upward = saturate_scalar(direction.y * 0.5 + 0.5);
+  let directional = mix(
+    wavefrontLightingParams.environment_color.xyz * 0.45,
+    wavefrontLightingParams.environment_color.xyz,
+    upward
+  );
+  let ambient = wavefrontLightingParams.ambient_color.xyz * 0.18;
+  let miss = wavefrontLightingParams.environment_miss_radiance.xyz;
+  return saturate_vec3(max(directional + ambient, miss));
+}
+
+fn terminal_radiance_for_hit(
+  hit: HitRecord,
+  ray: RayRecord,
+  emissive_radiance: vec3<f32>
+) -> vec3<f32> {
+  if (hit.hitType == HIT_TYPE_EMISSIVE) {
+    return ray.throughput * saturate_vec3(emissive_radiance);
+  }
+  if (hit.hitType == HIT_TYPE_ENVIRONMENT) {
+    return ray.throughput * environment_radiance(ray.direction);
+  }
+  if (hit.hitType == HIT_TYPE_MISS) {
+    let miss_radiance = max(
+      environment_radiance(ray.direction),
+      wavefrontLightingParams.environment_miss_radiance.xyz
+    );
+    return ray.throughput * saturate_vec3(miss_radiance);
+  }
+  return vec3<f32>(0.0);
+}
+
+fn reflect_direction(direction: vec3<f32>, normal: vec3<f32>) -> vec3<f32> {
+  return safe_normalize(reflect(direction, normal));
+}
+
+fn refract_direction(direction: vec3<f32>, normal: vec3<f32>, eta_ratio: f32) -> vec3<f32> {
+  let refracted = refract(direction, normal, eta_ratio);
+  if (dot(refracted, refracted) <= LIGHTING_EPSILON) {
+    return reflect_direction(direction, normal);
+  }
+  return safe_normalize(refracted);
+}
+
+fn choose_continuation_event_kind(hit: HitRecord, material: MaterialReferenceRecord) -> u32 {
+  if (hit.hitType == HIT_TYPE_TRANSPARENT || (material.flags & 0x4u) != 0u) {
+    return EVENT_KIND_TRANSPARENCY;
+  }
+  if ((material.flags & 0x8u) != 0u) {
+    return EVENT_KIND_REFRACTION;
+  }
+  if ((material.flags & 0x2u) != 0u) {
+    return EVENT_KIND_REFLECTION;
+  }
+  return EVENT_KIND_DIFFUSE;
+}
+
+fn material_base_albedo(material: MaterialReferenceRecord) -> vec3<f32> {
+  let tint = vec3<f32>(
+    f32((material.materialId & 0xffu)) / 255.0,
+    f32((material.textureSetId & 0xffu)) / 255.0,
+    f32(((material.materialId ^ material.textureSetId) & 0xffu)) / 255.0
+  );
+  return max(tint, vec3<f32>(0.12, 0.12, 0.12));
+}
+
+fn continuation_attenuation(event_kind: u32, material: MaterialReferenceRecord) -> vec3<f32> {
+  let base_albedo = material_base_albedo(material);
+  if (event_kind == EVENT_KIND_REFLECTION) {
+    return mix(vec3<f32>(0.04), base_albedo, 0.7);
+  }
+  if (event_kind == EVENT_KIND_REFRACTION) {
+    return vec3<f32>(0.92, 0.94, 0.98);
+  }
+  if (event_kind == EVENT_KIND_TRANSPARENCY) {
+    return vec3<f32>(0.75, 0.82, 0.9);
+  }
+  return base_albedo * LIGHTING_INV_PI;
+}

--- a/src/techniques/wavefront/scatter-continuations.job.wgsl
+++ b/src/techniques/wavefront/scatter-continuations.job.wgsl
@@ -1,0 +1,136 @@
+@group(0) @binding(0) var<uniform> wavefrontLightingParams: WavefrontLightingParams;
+@group(0) @binding(1) var<storage, read> activeQueue: array<RayRecord>;
+@group(0) @binding(2) var<storage, read> hitBuffer: array<HitRecord>;
+@group(0) @binding(3) var<storage, read> surfaceBuffer: array<SurfaceRecord>;
+@group(0) @binding(4) var<storage, read> materialRefBuffer: array<MaterialReferenceRecord>;
+@group(0) @binding(5) var<storage, read> mediumRefBuffer: array<MediumReferenceRecord>;
+@group(0) @binding(6) var<storage, read_write> nextQueue: array<RayRecord>;
+@group(0) @binding(7) var<storage, read_write> nextQueueCounter: atomic<u32>;
+
+fn queue_continuation_ray(
+  ray: RayRecord,
+  hit: HitRecord,
+  surface: SurfaceRecord,
+  direction: vec3<f32>,
+  attenuation: vec3<f32>
+) {
+  let slot = atomicAdd(&nextQueueCounter, 1u);
+  if (slot >= wavefrontLightingParams.next_queue_capacity) {
+    return;
+  }
+
+  let offset_origin =
+    ray.origin +
+    ray.direction * hit.distance +
+    faceforward_normal(surface.geometricNormal, ray.direction) * 0.001;
+  nextQueue[slot] = RayRecord(
+    ray.rayId ^ ((wavefrontLightingParams.bounce_index + 1u) * 0x9e3779b9u),
+    ray.rayId,
+    ray.sourcePixelId,
+    ray.sampleId,
+    wavefrontLightingParams.bounce_index + 1u,
+    offset_origin,
+    0.0,
+    direction,
+    0.0,
+    ray.throughput * attenuation,
+    surface.mediumRefId,
+    ray.flags
+  );
+}
+
+fn queue_reflection_continuation(
+  ray: RayRecord,
+  hit: HitRecord,
+  surface: SurfaceRecord,
+  material: MaterialReferenceRecord
+) {
+  let facing_normal = faceforward_normal(surface.shadingNormal, ray.direction);
+  let direction = reflect_direction(ray.direction, facing_normal);
+  let attenuation = continuation_attenuation(EVENT_KIND_REFLECTION, material);
+  queue_continuation_ray(ray, hit, surface, direction, attenuation);
+}
+
+fn queue_refraction_continuation(
+  ray: RayRecord,
+  hit: HitRecord,
+  surface: SurfaceRecord,
+  material: MaterialReferenceRecord
+) {
+  let front_face = hit.frontFace != 0u;
+  let facing_normal = faceforward_normal(surface.shadingNormal, ray.direction);
+  let eta_ratio = select(1.45, 1.0 / 1.45, front_face);
+  let direction = refract_direction(ray.direction, facing_normal, eta_ratio);
+  let attenuation = continuation_attenuation(EVENT_KIND_REFRACTION, material);
+  queue_continuation_ray(ray, hit, surface, direction, attenuation);
+}
+
+fn queue_transparency_continuation(
+  ray: RayRecord,
+  hit: HitRecord,
+  surface: SurfaceRecord,
+  material: MaterialReferenceRecord
+) {
+  let attenuation = continuation_attenuation(EVENT_KIND_TRANSPARENCY, material);
+  queue_continuation_ray(ray, hit, surface, ray.direction, attenuation);
+}
+
+fn queue_diffuse_continuation(
+  ray: RayRecord,
+  hit: HitRecord,
+  surface: SurfaceRecord,
+  material: MaterialReferenceRecord
+) {
+  let facing_normal = faceforward_normal(surface.shadingNormal, ray.direction);
+  let attenuation = continuation_attenuation(EVENT_KIND_DIFFUSE, material);
+  let bias =
+    surface.tangentFrame0 * (surface.uv.x - 0.5) +
+    surface.tangentFrame1 * (surface.uv.y - 0.5) +
+    facing_normal;
+  let direction = safe_normalize(bias);
+  queue_continuation_ray(ray, hit, surface, direction, attenuation);
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn process_job(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  let index = global_id.x;
+  if (index >= wavefrontLightingParams.active_count) {
+    return;
+  }
+  if (wavefrontLightingParams.bounce_index + 1u >= wavefrontLightingParams.max_depth) {
+    return;
+  }
+
+  let ray = activeQueue[index];
+  let hit = hitBuffer[index];
+  if (is_terminal_hit_type(hit.hitType) || hit.hitType == HIT_TYPE_MISS) {
+    return;
+  }
+
+  let surface = surfaceBuffer[index];
+  let material = materialRefBuffer[surface.materialRefId];
+  let _medium = mediumRefBuffer[surface.mediumRefId];
+  let event_kind = choose_continuation_event_kind(hit, material);
+  let explicit_light_sampling_enabled = wavefrontLightingParams.enable_explicit_light_sampling != 0u;
+
+  if (event_kind == EVENT_KIND_REFLECTION) {
+    queue_reflection_continuation(ray, hit, surface, material);
+    return;
+  }
+  if (event_kind == EVENT_KIND_REFRACTION) {
+    queue_refraction_continuation(ray, hit, surface, material);
+    return;
+  }
+  if (event_kind == EVENT_KIND_TRANSPARENCY) {
+    queue_transparency_continuation(ray, hit, surface, material);
+    return;
+  }
+
+  if (explicit_light_sampling_enabled) {
+    // Explicit light sampling remains optional for correctness in this first slice.
+    queue_diffuse_continuation(ray, hit, surface, material);
+    return;
+  }
+
+  queue_diffuse_continuation(ray, hit, surface, material);
+}

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -437,12 +437,13 @@ test("playwright capture helpers surface browser bootstrap failures and trim opt
 test("playwright capture helpers normalize output directories and summarize canvas pixels", async () => {
   const tempDirectory = path.join(os.tmpdir(), "plasius-capture-helper-test");
   const defaultOutputDirectory = resolveCaptureArtifactDirectory();
+  const workspaceRoot = resolveCaptureWorkspaceRoot();
   assert.ok(defaultOutputDirectory.endsWith("/output/playwright/eames-environments"));
   assert.equal(
     resolveCaptureArtifactDirectory("output/playwright/eames-environments/custom"),
-    path.resolve(process.cwd(), "..", "output/playwright/eames-environments/custom")
+    path.resolve(workspaceRoot, "output/playwright/eames-environments/custom")
   );
-  assert.equal(resolveCaptureWorkspaceRoot(), path.resolve(process.cwd(), ".."));
+  assert.equal(workspaceRoot, path.resolve(process.cwd(), "../.."));
   assert.equal(
     resolveCaptureArtifactDirectory(tempDirectory),
     tempDirectory
@@ -670,7 +671,10 @@ test("validation page restricts capture upload URLs to loopback bridges", () => 
 });
 
 test("validation page resolves the Eames model from the gpu-lighting repo path", () => {
-  assert.match(MODEL_URL, /\/gpu-lighting\/data\/models\/eames-lounge-chair-ottoman\//);
+  assert.match(
+    MODEL_URL,
+    /\/data\/models\/eames-lounge-chair-ottoman\/Eames_Lounge_Chair_Ottoman\.gltf$/
+  );
 });
 
 test("validation page reference camera is tighter than the wide orbit camera", () => {
@@ -1900,6 +1904,16 @@ test("every exported lighting job contains non-placeholder implementation marker
     "pathtracer.denoise": [
       /fn bilateral_weight\b/,
       /filtered_radiance/,
+    ],
+    "wavefront.accumulateTerminalRadiance": [
+      /fn accumulate_terminal_sample/,
+      /terminal_radiance_for_hit/,
+      /AccumulationRecord/,
+    ],
+    "wavefront.scatterContinuations": [
+      /fn queue_reflection_continuation/,
+      /fn queue_refraction_continuation/,
+      /fn queue_transparency_continuation/,
     ],
     "volumetrics.froxelIntegrate": [
       /FroxelGridParams/,

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -115,6 +115,17 @@ function urlToPath(url) {
   return fileURLToPath(url);
 }
 
+function deriveExpectedCaptureWorkspaceRoot() {
+  const captureRuntimeDirectory = path.dirname(
+    fileURLToPath(new URL("../scripts/eames-environments/capture-runtime.mjs", import.meta.url))
+  );
+  const packageRoot = path.resolve(captureRuntimeDirectory, "../..");
+  const directParent = path.resolve(packageRoot, "..");
+  return path.basename(directParent) === ".worktrees"
+    ? path.resolve(directParent, "..")
+    : directParent;
+}
+
 function roundColor(value) {
   return value.map((component) => Number(component.toFixed(4)));
 }
@@ -438,12 +449,13 @@ test("playwright capture helpers normalize output directories and summarize canv
   const tempDirectory = path.join(os.tmpdir(), "plasius-capture-helper-test");
   const defaultOutputDirectory = resolveCaptureArtifactDirectory();
   const workspaceRoot = resolveCaptureWorkspaceRoot();
+  const expectedWorkspaceRoot = deriveExpectedCaptureWorkspaceRoot();
   assert.ok(defaultOutputDirectory.endsWith("/output/playwright/eames-environments"));
   assert.equal(
     resolveCaptureArtifactDirectory("output/playwright/eames-environments/custom"),
     path.resolve(workspaceRoot, "output/playwright/eames-environments/custom")
   );
-  assert.equal(workspaceRoot, path.resolve(process.cwd(), "../.."));
+  assert.equal(workspaceRoot, expectedWorkspaceRoot);
   assert.equal(
     resolveCaptureArtifactDirectory(tempDirectory),
     tempDirectory

--- a/tests/wavefront-lighting.test.js
+++ b/tests/wavefront-lighting.test.js
@@ -1,0 +1,209 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createWavefrontPathTracingPlan,
+  rendererWavefrontPassOrder,
+  rendererWavefrontQueuePairStrategy,
+} from "@plasius/gpu-renderer";
+
+const originalImportMetaUrl = globalThis.__IMPORT_META_URL__;
+globalThis.__IMPORT_META_URL__ = new URL("../src/index.js", import.meta.url);
+const {
+  createWavefrontLightingPlan,
+  evaluateWavefrontContinuationEvent,
+  evaluateWavefrontTerminalRadiance,
+  getLightingTechnique,
+  getLightingTechniqueWorkerManifest,
+  lightingWavefrontBufferContracts,
+  lightingWavefrontPassOrder,
+  lightingWavefrontTerminationPolicy,
+  loadLightingTechniqueJobs,
+  loadLightingTechniqueWorkerBundle,
+} = await import("../src/index.js");
+if (typeof originalImportMetaUrl === "undefined") {
+  delete globalThis.__IMPORT_META_URL__;
+} else {
+  globalThis.__IMPORT_META_URL__ = originalImportMetaUrl;
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function roundVec3(value) {
+  return value.map((component) => Number(component.toFixed(4)));
+}
+
+function summarizeContracts(contracts) {
+  return Object.fromEntries(
+    Object.entries(contracts).map(([key, value]) => [
+      key,
+      {
+        recordName: value.recordName,
+        fields: value.fields.map((field) => field.name),
+      },
+    ])
+  );
+}
+
+test("wavefront lighting plan aligns with renderer queue, buffer, and termination contracts", () => {
+  const rendererPlan = createWavefrontPathTracingPlan({
+    maxDepth: 5,
+    queueCapacity: 2048,
+    explicitLightSampling: true,
+    accumulationResetEpoch: 9,
+  });
+  const lightingPlan = createWavefrontLightingPlan({
+    maxDepth: 5,
+    queueCapacity: 2048,
+    explicitLightSampling: true,
+    accumulationResetEpoch: 9,
+  });
+
+  assert.equal(lightingPlan.queueLayout.strategy, rendererWavefrontQueuePairStrategy);
+  assert.deepEqual(lightingPlan.queueLayout, rendererPlan.queueLayout);
+  assert.deepEqual(
+    summarizeContracts(lightingPlan.bufferContracts),
+    summarizeContracts(rendererPlan.bufferContracts)
+  );
+  assert.deepEqual(lightingPlan.terminationPolicy, rendererPlan.terminationPolicy);
+  assert.deepEqual(lightingPlan.requiredRendererPassOrder, rendererWavefrontPassOrder);
+  assert.deepEqual(
+    lightingPlan.lightingPasses.map((pass) => pass.key),
+    lightingWavefrontPassOrder
+  );
+  assert.deepEqual(
+    summarizeContracts(lightingWavefrontBufferContracts),
+    summarizeContracts(rendererPlan.bufferContracts)
+  );
+  assert.deepEqual(lightingWavefrontTerminationPolicy, rendererPlan.terminationPolicy);
+});
+
+test("wavefront lighting technique and worker manifest expose the renderer-aligned lighting slice", async () => {
+  const technique = getLightingTechnique("wavefront");
+  assert.equal(technique.name, "wavefront");
+  assert.equal(technique.jobs.length, 2);
+  assert.deepEqual(
+    technique.jobs.map((job) => job.key),
+    ["accumulateTerminalRadiance", "scatterContinuations"]
+  );
+
+  const manifest = getLightingTechniqueWorkerManifest("wavefront");
+  assert.equal(manifest.queueClass, "lighting");
+  assert.equal(manifest.jobs.length, 2);
+  assert.deepEqual(
+    manifest.jobs.find((job) => job.key === "scatterContinuations").worker.dependencies,
+    ["lighting.wavefront.accumulateTerminalRadiance"]
+  );
+
+  const bundle = await loadLightingTechniqueWorkerBundle("wavefront");
+  assert.equal(bundle.technique, "wavefront");
+  assert.equal(bundle.jobs.length, 2);
+
+  const loaded = await loadLightingTechniqueJobs("wavefront");
+  assert.equal(loaded.jobs.length, 2);
+  assert.ok(
+    loaded.jobs.every((job) => typeof job.wgsl === "string" && job.wgsl.includes("process_job"))
+  );
+});
+
+test("wavefront terminal lighting reference helpers cover emissive, environment, and dark miss termination", () => {
+  const emissive = evaluateWavefrontTerminalRadiance({
+    hitType: "emissive",
+    throughput: [0.5, 0.25, 0.75],
+    emission: [4, 2, 1],
+  });
+  assert.equal(emissive.terminated, true);
+  assert.equal(emissive.source, "emissive");
+  assert.deepEqual(roundVec3(emissive.radiance), [2, 0.5, 0.75]);
+
+  const environment = evaluateWavefrontTerminalRadiance({
+    hitType: "environment",
+    throughput: [1, 0.5, 0.25],
+    environmentRadiance: [0.2, 0.3, 0.4],
+  });
+  assert.equal(environment.source, "environment");
+  assert.deepEqual(roundVec3(environment.radiance), [0.2, 0.15, 0.1]);
+
+  const miss = evaluateWavefrontTerminalRadiance({
+    hitType: "miss",
+    throughput: [1, 1, 1],
+    environmentRadiance: [0, 0, 0],
+  });
+  assert.equal(miss.source, "dark");
+  assert.equal(miss.nearDarkSample, true);
+  assert.deepEqual(roundVec3(miss.radiance), [0.0001, 0.0001, 0.0001]);
+});
+
+test("wavefront continuation reference helpers cover reflection, refraction, and transparency events", () => {
+  const reflection = evaluateWavefrontContinuationEvent({
+    hitType: "surface",
+    eventKind: "reflection",
+    throughput: [1, 0.8, 0.6],
+    albedo: [0.9, 0.7, 0.5],
+    metalness: 1,
+    roughness: 0.1,
+    shadingNormal: [0, 1, 0],
+    viewDirection: [0, 1, 0],
+  });
+  assert.equal(reflection.eventKind, "reflection");
+  assert.equal(reflection.continueTracing, true);
+  assert.ok(reflection.nextDirection[1] > 0);
+
+  const refraction = evaluateWavefrontContinuationEvent({
+    hitType: "surface",
+    eventKind: "refraction",
+    throughput: [0.9, 0.9, 0.9],
+    transmission: [0.92, 0.95, 0.98],
+    shadingNormal: [0, 1, 0],
+    viewDirection: [0, 1, 0],
+    frontFace: true,
+    ior: 1.45,
+  });
+  assert.equal(refraction.eventKind, "refraction");
+  assert.equal(refraction.continueTracing, true);
+  assert.ok(refraction.nextDirection[1] < 0);
+
+  const transparency = evaluateWavefrontContinuationEvent({
+    hitType: "transparent",
+    throughput: [0.7, 0.7, 0.7],
+    opacity: 0.2,
+    viewDirection: [0, 1, 0],
+    shadingNormal: [0, 1, 0],
+  });
+  assert.equal(transparency.eventKind, "transparency");
+  assert.equal(transparency.continueTracing, true);
+  assert.deepEqual(roundVec3(transparency.nextDirection), [0, -1, 0]);
+});
+
+test("wavefront WGSL sources publish terminal-radiance and continuation jobs rather than placeholder kernels", () => {
+  const base = path.resolve(__dirname, "..", "src", "techniques", "wavefront");
+  const prelude = fs.readFileSync(path.join(base, "prelude.wgsl"), "utf8");
+  const accumulate = fs.readFileSync(
+    path.join(base, "accumulate-terminal-radiance.job.wgsl"),
+    "utf8"
+  );
+  const scatter = fs.readFileSync(
+    path.join(base, "scatter-continuations.job.wgsl"),
+    "utf8"
+  );
+
+  assert.match(prelude, /struct RayRecord/);
+  assert.match(prelude, /struct HitRecord/);
+  assert.match(prelude, /struct SurfaceRecord/);
+  assert.match(prelude, /struct AccumulationRecord/);
+  assert.match(prelude, /fn terminal_radiance_for_hit/);
+
+  assert.match(accumulate, /fn accumulate_terminal_sample/);
+  assert.match(accumulate, /terminal_radiance_for_hit/);
+  assert.match(accumulate, /@compute\s+@workgroup_size/);
+  assert.doesNotMatch(accumulate, /Placeholder/);
+
+  assert.match(scatter, /fn queue_reflection_continuation/);
+  assert.match(scatter, /fn queue_refraction_continuation/);
+  assert.match(scatter, /fn queue_transparency_continuation/);
+  assert.match(scatter, /enable_explicit_light_sampling/);
+  assert.doesNotMatch(scatter, /Placeholder/);
+});


### PR DESCRIPTION
## Summary
- add a renderer-aligned `wavefront` lighting technique with terminal-radiance and continuation WGSL jobs
- publish wavefront plan/reference helpers plus contract tests against the published `@plasius/gpu-renderer` surface
- make the Eames capture helpers and tests worktree-safe so validation stays green in clean delivery worktrees

## Linked work
- Plasius-LTD/plasius-ltd-site#1039
- Plasius-LTD/gpu-lighting#27
- Plasius-LTD/gpu-lighting#28

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:coverage`
- `NPM_CONFIG_CACHE=/Users/philliphounslow/plasius/.npm-cache-hw2 npm run pack:check`
- `NPM_CONFIG_CACHE=/Users/philliphounslow/plasius/.npm-cache-hw2 npm pack --dry-run`