### PR TITLE
feat: expand Eames validation matrix artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - Extended the wavefront lighting contract with compact medium-state carry,
     visibility-probe ray helpers, MIS/exclusive-emissive probe controls, and
     deterministic CPU reference fixtures for continuation validation.
+  - The Eames validation harness now supports scripted quick/full screenshot
+    matrices with configurable camera, SPP, and denoise combinations plus
+    manifest-level failure diagnostics for reference runs.
 
 - **Changed**
   - Wavefront ray-record documentation now mirrors the current renderer payload
@@ -20,6 +23,9 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - The Eames validation page now defaults display-quality captures to
     `accelerationBuildMode=cpu-upload` while still allowing explicit GPU BVH
     validation through the query parameter.
+  - Eames per-capture JSON artifacts now include capture URLs, repro commands,
+    luminance spread, and quantized color-bucket metrics so regression reports
+    retain lightweight texture-presence evidence alongside black-pixel counts.
 
 - **Fixed**
   - Wavefront continuation helpers now report total internal reflection

--- a/README.md
+++ b/README.md
@@ -97,11 +97,24 @@ overridden:
 - `PLASIUS_CAPTURE_FRAME_INDEX=777`
 - `PLASIUS_CAPTURE_PROBE=1`
 
-They save canvas-only PNGs plus per-capture JSON under
-`output/playwright/eames-environments/`, including exact-black, near-black, and
-average-luminance metrics so screenshot comparisons stay apples-to-apples. The
-validation page now decouples optional probe readback from the heavy render
-submission itself, which keeps higher-SPP screenshot validation more stable.
+The main screenshot harness now supports a scripted matrix:
+
+- `PLASIUS_CAPTURE_MATRIX_MODE=quick` keeps the default one-scenario-per-preset
+  lane for faster local checks.
+- `PLASIUS_CAPTURE_MATRIX_MODE=full` expands into a cross-product over camera
+  presets, SPP values, and denoise states for offline/reference validation.
+- `PLASIUS_CAPTURE_CAMERA_PRESETS=reference,wide`,
+  `PLASIUS_CAPTURE_SPP_MATRIX=1,4,8,32,128`, and
+  `PLASIUS_CAPTURE_DENOISE_MATRIX=1,0` refine the matrix explicitly.
+
+They save canvas-only PNGs plus per-scenario JSON under
+`output/playwright/eames-environments/`, including the capture URL, a repro
+command, renderer stats, exact-black/near-black counts, luminance spread, and
+quantized color-bucket metrics that act as lightweight texture-presence
+signals. The manifest and summary now also retain failure diagnostics instead of
+stopping with only terminal output. The validation page now decouples optional
+probe readback from the heavy render submission itself, which keeps higher-SPP
+screenshot validation more stable.
 For motion or realtime validation, the page also accepts `frameTimeBudgetMs`
 and will render at least one full-screen sample before adaptively spending the
 rest of the per-frame budget on additional SPP passes. The HUD reports

--- a/scripts/eames-environments/capture-runtime.mjs
+++ b/scripts/eames-environments/capture-runtime.mjs
@@ -74,6 +74,10 @@ export function summarizeRgbaPixels(rgbaBytes) {
   let nearBlackPixels16 = 0;
   let opaquePixels = 0;
   let luminanceTotal = 0;
+  let luminanceSquaredTotal = 0;
+  let minLuminance = Number.POSITIVE_INFINITY;
+  let maxLuminance = 0;
+  const quantizedColorBuckets = new Map();
   for (let index = 0; index < rgbaBytes.length; index += 4) {
     const red = rgbaBytes[index];
     const green = rgbaBytes[index + 1];
@@ -93,14 +97,36 @@ export function summarizeRgbaPixels(rgbaBytes) {
     if (maxChannel <= 16) {
       nearBlackPixels16 += 1;
     }
-    luminanceTotal += (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255;
+    const luminance = (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255;
+    luminanceTotal += luminance;
+    luminanceSquaredTotal += luminance * luminance;
+    minLuminance = Math.min(minLuminance, luminance);
+    maxLuminance = Math.max(maxLuminance, luminance);
+    const bucketKey = [
+      Math.floor(red / 32),
+      Math.floor(green / 32),
+      Math.floor(blue / 32),
+    ].join(":");
+    quantizedColorBuckets.set(bucketKey, (quantizedColorBuckets.get(bucketKey) ?? 0) + 1);
   }
+  const averageLuminance = opaquePixels > 0 ? luminanceTotal / opaquePixels : 0;
+  const luminanceVariance =
+    opaquePixels > 0
+      ? Math.max(0, luminanceSquaredTotal / opaquePixels - averageLuminance * averageLuminance)
+      : 0;
+  const dominantQuantizedBucketPixels = Math.max(0, ...quantizedColorBuckets.values());
   return {
     exactBlackPixels,
     nearBlackPixels8,
     nearBlackPixels16,
     opaquePixels,
-    averageLuminance: opaquePixels > 0 ? luminanceTotal / opaquePixels : 0,
+    averageLuminance,
+    minLuminance: opaquePixels > 0 ? minLuminance : 0,
+    maxLuminance,
+    luminanceStdDev: Math.sqrt(luminanceVariance),
+    quantizedColorBucketCount: quantizedColorBuckets.size,
+    dominantQuantizedBucketShare:
+      opaquePixels > 0 ? dominantQuantizedBucketPixels / opaquePixels : 0,
   };
 }
 

--- a/scripts/eames-environments/capture.mjs
+++ b/scripts/eames-environments/capture.mjs
@@ -28,6 +28,18 @@ const defaultDeferredPathResolve = process.env.PLASIUS_CAPTURE_DEFERRED !== "0";
 const defaultCaptureDenoise = process.env.PLASIUS_CAPTURE_DENOISE !== "0";
 const defaultCaptureMotion = process.env.PLASIUS_CAPTURE_MOTION === "1";
 const defaultCaptureShowSources = process.env.PLASIUS_CAPTURE_SHOW_SOURCES === "1";
+const defaultMatrixMode = readCaptureMatrixMode(process.env.PLASIUS_CAPTURE_MATRIX_MODE);
+const defaultCameraPresets = readCaptureCameraPresets(process.env.PLASIUS_CAPTURE_CAMERA_PRESETS);
+const defaultSamplesPerPixelMatrix = readCaptureIntegerList(
+  process.env.PLASIUS_CAPTURE_SPP_MATRIX,
+  defaultMatrixMode === "full" ? [1, 4, 8, 32, 128] : [defaultCaptureSamplesPerPixel],
+  1,
+  256
+);
+const defaultDenoiseMatrix = readCaptureBooleanList(
+  process.env.PLASIUS_CAPTURE_DENOISE_MATRIX,
+  defaultMatrixMode === "full" ? [true, false] : [defaultCaptureDenoise]
+);
 const captureLabel = sanitizeCaptureLabel(
   process.env.PLASIUS_CAPTURE_LABEL ?? (defaultDeferredPathResolve ? "deferred" : "legacy")
 );
@@ -63,6 +75,17 @@ export function computeCaptureReadyTimeoutMs(options = {}) {
   return Math.min(900_000, 60_000 + workEstimate * 30);
 }
 
+function readCaptureMatrixMode(value) {
+  const selected = String(value ?? "quick").trim().toLowerCase();
+  if (!selected) {
+    return "quick";
+  }
+  if (selected !== "quick" && selected !== "full") {
+    throw new Error("PLASIUS_CAPTURE_MATRIX_MODE must be 'quick' or 'full'.");
+  }
+  return selected;
+}
+
 function readCaptureInteger(name, fallback, minimum, maximum) {
   const value = Number(process.env[name]);
   if (!Number.isFinite(value)) {
@@ -74,6 +97,57 @@ function readCaptureInteger(name, fallback, minimum, maximum) {
 function sanitizeCaptureLabel(value) {
   const label = String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9-]+/g, "-");
   return label || "capture";
+}
+
+function readCaptureIntegerList(value, fallback, minimum, maximum) {
+  const raw = String(value ?? "").trim();
+  const values = raw
+    ? raw
+        .split(",")
+        .map((entry) => Number(entry.trim()))
+        .filter(Number.isFinite)
+        .map((entry) => Math.max(minimum, Math.min(maximum, Math.round(entry))))
+    : fallback;
+  if (!Array.isArray(values) || values.length === 0) {
+    throw new Error("Capture integer matrix must contain at least one numeric value.");
+  }
+  return [...new Set(values)];
+}
+
+function readCaptureBooleanList(value, fallback) {
+  const raw = String(value ?? "").trim();
+  if (!raw) {
+    return fallback;
+  }
+  const values = raw
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean)
+    .map((entry) => {
+      if (["1", "true", "on", "yes"].includes(entry)) {
+        return true;
+      }
+      if (["0", "false", "off", "no"].includes(entry)) {
+        return false;
+      }
+      throw new Error(`Unsupported boolean matrix value '${entry}'.`);
+    });
+  return [...new Set(values)];
+}
+
+function readCaptureCameraPresets(value) {
+  const fallback = defaultMatrixMode === "full" ? ["reference", "wide"] : ["reference"];
+  const selected = String(value ?? "")
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+  const values = selected.length > 0 ? selected : fallback;
+  for (const cameraPreset of values) {
+    if (!["reference", "wide"].includes(cameraPreset)) {
+      throw new Error(`Unsupported capture camera preset '${cameraPreset}'.`);
+    }
+  }
+  return [...new Set(values)];
 }
 
 function readCapturePresets(value, fallback) {
@@ -92,86 +166,218 @@ function readCapturePresets(value, fallback) {
   return selected;
 }
 
-async function capturePreset(page, baseUrl, preset, geometry) {
-  const artifactDirectory = await artifactDirectoryPromise;
+function buildScenarioId({
+  preset,
+  geometry,
+  cameraPreset,
+  samplesPerPixel,
+  denoise,
+}) {
+  return [
+    "eames",
+    preset,
+    geometry,
+    cameraPreset,
+    `${samplesPerPixel}spp`,
+    denoise ? "denoise-on" : "denoise-off",
+    captureLabel,
+  ].join("-");
+}
+
+function buildScenarioReproCommand(scenario) {
+  const environment = [
+    `PLASIUS_CAPTURE_PRESETS=${scenario.preset}`,
+    `PLASIUS_CAPTURE_CAMERA_PRESETS=${scenario.cameraPreset}`,
+    `PLASIUS_CAPTURE_SPP_MATRIX=${scenario.samplesPerPixel}`,
+    `PLASIUS_CAPTURE_DENOISE_MATRIX=${scenario.denoise ? 1 : 0}`,
+    `PLASIUS_CAPTURE_MATRIX_MODE=quick`,
+    `PLASIUS_CAPTURE_LABEL=${captureLabel}`,
+  ];
+  if (defaultCaptureFrames !== 1) {
+    environment.push(`PLASIUS_CAPTURE_FRAMES=${defaultCaptureFrames}`);
+  }
+  if (defaultCaptureMaxDepth !== 8) {
+    environment.push(`PLASIUS_CAPTURE_MAX_DEPTH=${defaultCaptureMaxDepth}`);
+  }
+  return `${environment.join(" ")} node scripts/eames-environments/capture.mjs`;
+}
+
+export function createCaptureScenarios(options = {}) {
+  const matrixMode = options.matrixMode ?? defaultMatrixMode;
+  const cameraPresets = options.cameraPresets ?? defaultCameraPresets;
+  const samplesPerPixelMatrix = options.samplesPerPixelMatrix ?? defaultSamplesPerPixelMatrix;
+  const denoiseMatrix = options.denoiseMatrix ?? defaultDenoiseMatrix;
+  const geometry = options.geometry ?? "mesh";
+  return presets.flatMap((preset) =>
+    cameraPresets.flatMap((cameraPreset) =>
+      samplesPerPixelMatrix.flatMap((samplesPerPixel) =>
+        denoiseMatrix.map((denoise) => ({
+          id: buildScenarioId({
+            preset,
+            geometry,
+            cameraPreset,
+            samplesPerPixel,
+            denoise,
+          }),
+          preset,
+          geometry,
+          cameraPreset,
+          denoise,
+          samplesPerPixel,
+          matrixMode,
+          reproCommand: buildScenarioReproCommand({
+            preset,
+            geometry,
+            cameraPreset,
+            denoise,
+            samplesPerPixel,
+          }),
+        }))
+      )
+    )
+  );
+}
+
+function buildFailureDiagnostic(error, scenario, captureUrl) {
+  return {
+    scenarioId: scenario.id,
+    preset: scenario.preset,
+    geometry: scenario.geometry,
+    cameraPreset: scenario.cameraPreset,
+    samplesPerPixel: scenario.samplesPerPixel,
+    denoise: scenario.denoise,
+    captureUrl,
+    reproCommand: scenario.reproCommand,
+    message: String(error?.message ?? error ?? "Unknown capture failure."),
+    cause: error?.cause ? String(error.cause.message ?? error.cause) : null,
+  };
+}
+
+function buildBootstrapFailureDiagnostic(error, baseUrl, scenarios) {
+  return {
+    scenarioId: "browser-bootstrap",
+    preset: scenarios[0]?.preset ?? null,
+    geometry: scenarios[0]?.geometry ?? "mesh",
+    cameraPreset: null,
+    samplesPerPixel: null,
+    denoise: null,
+    captureUrl: new URL("/gpu-lighting/demo/eames-environments/index.html", baseUrl).href,
+    reproCommand:
+      "Start a WebGPU-capable Chrome with remote debugging and set PLASIUS_CAPTURE_CDP_URL=http://127.0.0.1:<port>.",
+    message: String(error?.message ?? error ?? "Browser bootstrap failed."),
+    cause: error?.cause ? String(error.cause.message ?? error.cause) : null,
+  };
+}
+
+function buildCaptureUrl(baseUrl, scenario) {
   const url = new URL("/gpu-lighting/demo/eames-environments/index.html", baseUrl);
-  url.searchParams.set("preset", preset);
-  url.searchParams.set("geometry", geometry);
+  url.searchParams.set("preset", scenario.preset);
+  url.searchParams.set("geometry", scenario.geometry);
   url.searchParams.set("width", String(defaultCaptureWidth));
   url.searchParams.set("height", String(defaultCaptureHeight));
   url.searchParams.set("frames", String(defaultCaptureFrames));
   url.searchParams.set("maxDepth", String(defaultCaptureMaxDepth));
-  url.searchParams.set("samplesPerPixel", String(defaultCaptureSamplesPerPixel));
-  url.searchParams.set("denoise", defaultCaptureDenoise ? "1" : "0");
+  url.searchParams.set("samplesPerPixel", String(scenario.samplesPerPixel));
+  url.searchParams.set("denoise", scenario.denoise ? "1" : "0");
   url.searchParams.set("motion", defaultCaptureMotion ? "1" : "0");
   url.searchParams.set("probe", captureProbeReadback ? "1" : "0");
   url.searchParams.set("deferredPathResolve", defaultDeferredPathResolve ? "1" : "0");
   url.searchParams.set("frameIndex", String(defaultCaptureFrameIndex));
   url.searchParams.set("showSources", defaultCaptureShowSources ? "1" : "0");
+  url.searchParams.set("cameraPreset", scenario.cameraPreset);
+  return url;
+}
+
+async function captureScenario(page, baseUrl, scenario) {
+  const artifactDirectory = await artifactDirectoryPromise;
+  const url = buildCaptureUrl(baseUrl, scenario);
 
   const readyTimeoutMs = computeCaptureReadyTimeoutMs({
     width: defaultCaptureWidth,
     height: defaultCaptureHeight,
     frames: defaultCaptureFrames,
     maxDepth: defaultCaptureMaxDepth,
-    samplesPerPixel: defaultCaptureSamplesPerPixel,
+    samplesPerPixel: scenario.samplesPerPixel,
   });
 
   await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: 60_000 });
-  await waitForCaptureReady(page, preset, readyTimeoutMs);
+  await waitForCaptureReady(page, scenario.id, readyTimeoutMs);
   const result = await page.evaluate(() => window.__plasiusCaptureResult ?? window.__plasiusCaptureError);
   if (!result || result.status !== "ok") {
-    throw new Error(formatCaptureDiagnostic(preset, await readPageDiagnostic(page)));
+    throw new Error(formatCaptureDiagnostic(scenario.id, await readPageDiagnostic(page)));
   }
   if (result.geometry !== "mesh") {
-    throw new Error(`${preset} captured ${result.geometry} geometry; Eames validation must use mesh triangles.`);
+    throw new Error(
+      `${scenario.id} captured ${result.geometry} geometry; Eames validation must use mesh triangles.`
+    );
   }
   if (result.maxDepth !== defaultCaptureMaxDepth) {
-    throw new Error(`${preset} rendered maxDepth=${result.maxDepth}; expected ${defaultCaptureMaxDepth}.`);
-  }
-  if (result.samplesPerPixel !== defaultCaptureSamplesPerPixel) {
     throw new Error(
-      `${preset} rendered samplesPerPixel=${result.samplesPerPixel}; expected ${defaultCaptureSamplesPerPixel}.`
+      `${scenario.id} rendered maxDepth=${result.maxDepth}; expected ${defaultCaptureMaxDepth}.`
+    );
+  }
+  if (result.samplesPerPixel !== scenario.samplesPerPixel) {
+    throw new Error(
+      `${scenario.id} rendered samplesPerPixel=${result.samplesPerPixel}; expected ${scenario.samplesPerPixel}.`
     );
   }
   if (result.frames !== defaultCaptureFrames) {
-    throw new Error(`${preset} rendered frames=${result.frames}; expected ${defaultCaptureFrames}.`);
+    throw new Error(`${scenario.id} rendered frames=${result.frames}; expected ${defaultCaptureFrames}.`);
   }
-  if (result.denoise !== defaultCaptureDenoise) {
-    throw new Error(`${preset} rendered denoise=${result.denoise}; expected ${defaultCaptureDenoise}.`);
+  if (result.denoise !== scenario.denoise) {
+    throw new Error(`${scenario.id} rendered denoise=${result.denoise}; expected ${scenario.denoise}.`);
   }
   if (result.motion !== defaultCaptureMotion) {
-    throw new Error(`${preset} rendered motion=${result.motion}; expected ${defaultCaptureMotion}.`);
+    throw new Error(`${scenario.id} rendered motion=${result.motion}; expected ${defaultCaptureMotion}.`);
+  }
+  if (result.cameraPreset !== scenario.cameraPreset) {
+    throw new Error(
+      `${scenario.id} rendered cameraPreset=${result.cameraPreset}; expected ${scenario.cameraPreset}.`
+    );
   }
   if (result.meshCount <= 0 || result.renderer.triangleCount <= 0) {
     throw new Error(
-      `${preset} did not render triangle mesh geometry: ${result.meshCount} meshes, ${result.renderer.triangleCount} renderer triangles.`
+      `${scenario.id} did not render triangle mesh geometry: ${result.meshCount} meshes, ${result.renderer.triangleCount} renderer triangles.`
     );
   }
   if (
     result.probeReadback &&
     (result.probeSummary.nonZeroSamples <= 0 || !Number.isFinite(result.probeSummary.averageLuminance))
   ) {
-    throw new Error(`${preset} rendered a blank or invalid output probe.`);
+    throw new Error(`${scenario.id} rendered a blank or invalid output probe.`);
   }
 
   const canvasCapture = await readCanvasCapture(page);
   if (!canvasCapture?.dataUrl) {
-    throw new Error(`${preset} did not expose a readable render canvas.`);
+    throw new Error(`${scenario.id} did not expose a readable render canvas.`);
   }
   const canvasStats = summarizeRgbaPixels(canvasCapture.rgbaBytes);
-  const screenshotPath = path.join(artifactDirectory, `eames-${preset}-${geometry}-${captureLabel}.png`);
+  const screenshotPath = path.join(artifactDirectory, `${scenario.id}.png`);
   const screenshotBytes = await writePngDataUrl(screenshotPath, canvasCapture.dataUrl);
   if (screenshotBytes < minimumScreenshotBytes) {
-    throw new Error(`${preset} screenshot is unexpectedly small: ${screenshotBytes} bytes.`);
+    throw new Error(`${scenario.id} screenshot is unexpectedly small: ${screenshotBytes} bytes.`);
   }
-  const resultPath = path.join(artifactDirectory, `eames-${preset}-${geometry}-${captureLabel}.json`);
+  const resultPath = path.join(artifactDirectory, `${scenario.id}.json`);
+  const captureUrl = url.href;
   await fs.writeFile(
     resultPath,
-    `${JSON.stringify({ ...result, canvasStats }, null, 2)}\n`,
+    `${JSON.stringify(
+      {
+        scenario,
+        captureUrl,
+        reproCommand: scenario.reproCommand,
+        canvasStats,
+        ...result,
+      },
+      null,
+      2
+    )}\n`,
     "utf8"
   );
   return {
+    scenario,
+    captureUrl,
+    reproCommand: scenario.reproCommand,
     ...result,
     canvasStats,
     screenshot: screenshotPath,
@@ -182,13 +388,60 @@ async function capturePreset(page, baseUrl, preset, geometry) {
   };
 }
 
+function renderCaptureSummary(manifest) {
+  return [
+    `# Eames Environment Lighting Screenshots`,
+    ``,
+    `Matrix mode: ${manifest.matrixMode}`,
+    `Scenario count: ${manifest.scenarios.length}`,
+    `Resolution: ${defaultCaptureWidth}x${defaultCaptureHeight}`,
+    `Frames: ${defaultCaptureFrames}`,
+    `Max depth: ${defaultCaptureMaxDepth}`,
+    `Deferred: ${defaultDeferredPathResolve ? "on" : "off"}`,
+    `Motion: ${defaultCaptureMotion ? "on" : "off"}`,
+    `Probe readback: ${captureProbeReadback ? "on" : "off"}`,
+    `Frame seed index: ${defaultCaptureFrameIndex}`,
+    ``,
+    `| Scenario | Camera | SPP | Denoise | Black | Near <=16 | Avg lum | Lum stddev | Color buckets | Dominant bucket share | Screenshot |`,
+    `| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |`,
+    ...manifest.results.map((result) => {
+      const metrics = result.canvasStats;
+      return `| ${result.scenario.id} | ${result.scenario.cameraPreset} | ${result.scenario.samplesPerPixel} | ` +
+        `${result.scenario.denoise ? "on" : "off"} | ${metrics.exactBlackPixels} | ${metrics.nearBlackPixels16} | ` +
+        `${metrics.averageLuminance.toFixed(4)} | ${metrics.luminanceStdDev.toFixed(4)} | ` +
+        `${metrics.quantizedColorBucketCount} | ${metrics.dominantQuantizedBucketShare.toFixed(4)} | ` +
+        `${result.screenshotRelative} |`;
+    }),
+    ``,
+    manifest.failures.length > 0 ? `## Failures` : null,
+    ...manifest.failures.map((failure) =>
+      `- ${failure.scenarioId}: ${failure.message} | URL: ${failure.captureUrl} | Repro: \`${failure.reproCommand}\``
+    ),
+    ``,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
 async function captureMatrix(geometry) {
   const serverSession = await openCaptureServerSession();
+  const scenarios = createCaptureScenarios({ geometry });
 
   let browserSession;
   try {
     const baseUrl = serverSession.baseUrl;
-    browserSession = await openCaptureBrowser();
+    try {
+      browserSession = await openCaptureBrowser();
+    } catch (error) {
+      return {
+        geometry,
+        matrixMode: defaultMatrixMode,
+        baseUrl,
+        scenarios,
+        results: [],
+        failures: [buildBootstrapFailureDiagnostic(error, baseUrl, scenarios)],
+      };
+    }
     const page = await browserSession.context.newPage({
       viewport: { width: defaultCaptureWidth, height: defaultCaptureHeight },
       deviceScaleFactor: 1,
@@ -215,14 +468,24 @@ async function captureMatrix(geometry) {
     });
 
     const results = [];
-    for (const preset of presets) {
-      console.log(`capturing ${preset} (${geometry})`);
-      results.push(await capturePreset(page, baseUrl, preset, geometry));
+    const failures = [];
+    for (const scenario of scenarios) {
+      console.log(`capturing ${scenario.id}`);
+      try {
+        results.push(await captureScenario(page, baseUrl, scenario));
+      } catch (error) {
+        const failure = buildFailureDiagnostic(error, scenario, buildCaptureUrl(baseUrl, scenario).href);
+        failures.push(failure);
+        console.error(`${failure.scenarioId} failed: ${failure.message}`);
+      }
     }
     return {
       geometry,
+      matrixMode: defaultMatrixMode,
       baseUrl: serverSession.baseUrl,
+      scenarios,
       results,
+      failures,
     };
   } finally {
     await browserSession?.close();
@@ -237,42 +500,14 @@ async function main() {
   const manifestPath = path.join(artifactDirectory, "manifest.json");
   await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
   const summaryPath = path.join(artifactDirectory, "summary.md");
-  await fs.writeFile(
-    summaryPath,
-    [
-      `# Eames Environment Lighting Screenshots`,
-      ``,
-      `Geometry: ${manifest.geometry}`,
-      `Resolution: ${defaultCaptureWidth}x${defaultCaptureHeight}`,
-      `Frames: ${defaultCaptureFrames}`,
-      `Max depth: ${defaultCaptureMaxDepth}`,
-      `SPP: ${defaultCaptureSamplesPerPixel}`,
-      `Denoise: ${defaultCaptureDenoise ? "on" : "off"}`,
-      `Deferred: ${defaultDeferredPathResolve ? "on" : "off"}`,
-      `Motion: ${defaultCaptureMotion ? "on" : "off"}`,
-      `Frame seed index: ${defaultCaptureFrameIndex}`,
-      ``,
-      ...manifest.results.map((result) => {
-        const probe = result.probeSummary;
-        const parallelism = result.renderer.gpuParallelism;
-        const probeText = result.probeReadback
-          ? `${probe.nonZeroSamples}/${probe.sampledPixels} lit probe samples, avg luminance ${probe.averageLuminance.toFixed(4)}`
-          : "probe readback disabled";
-        const canvasText = `${result.canvasStats.exactBlackPixels} black, ` +
-          `${result.canvasStats.nearBlackPixels8} <=8, ` +
-          `${result.canvasStats.nearBlackPixels16} <=16, avg canvas luminance ` +
-          `${result.canvasStats.averageLuminance.toFixed(4)}`;
-        const parallelismText = parallelism
-          ? `${parallelism.directWorkgroups} direct workgroups, ${parallelism.indirectDispatches} indirect dispatches, multi-workgroup ${parallelism.exposesMultiWorkgroupParallelism ? "yes" : "no"}`
-          : "parallelism unavailable";
-        return `- ${result.preset}: ${result.screenshotRelative}, ${result.screenshotBytes} bytes, ${probeText}, ${canvasText}, ${parallelismText}`;
-      }),
-      ``,
-    ].join("\n"),
-    "utf8"
-  );
+  await fs.writeFile(summaryPath, `${renderCaptureSummary(manifest)}\n`, "utf8");
   console.log(`wrote ${manifestPath}`);
   console.log(`wrote ${summaryPath}`);
+  if (manifest.failures.length > 0) {
+    throw new Error(
+      `Capture matrix completed with ${manifest.failures.length} failure(s). See ${path.relative(repoRoot, manifestPath)}.`
+    );
+  }
 }
 
 if (!globalThis.__PLASIUS_EAMES_CAPTURE_MODULE_ONLY__) {

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -69,6 +69,7 @@ const previousEamesCaptureModuleOnly = globalThis.__PLASIUS_EAMES_CAPTURE_MODULE
 globalThis.__PLASIUS_EAMES_CAPTURE_MODULE_ONLY__ = true;
 const {
   computeCaptureReadyTimeoutMs,
+  createCaptureScenarios,
 } = await import("../scripts/eames-environments/capture.mjs");
 if (typeof previousEamesCaptureModuleOnly === "undefined") {
   delete globalThis.__PLASIUS_EAMES_CAPTURE_MODULE_ONLY__;
@@ -499,6 +500,10 @@ test("playwright capture helpers normalize output directories and summarize canv
   assert.equal(summary.nearBlackPixels16, 3);
   assert.equal(summary.opaquePixels, 4);
   assert.ok(summary.averageLuminance > 0);
+  assert.ok(summary.maxLuminance >= summary.averageLuminance);
+  assert.ok(summary.luminanceStdDev > 0);
+  assert.equal(summary.quantizedColorBucketCount, 2);
+  assert.equal(summary.dominantQuantizedBucketShare, 0.75);
 
   const outputDirectory = await ensureCaptureArtifactDirectory(tempDirectory);
   assert.equal(outputDirectory, tempDirectory);
@@ -514,6 +519,32 @@ test("playwright capture helpers normalize output directories and summarize canv
     () => decodePngDataUrl("data:text/plain;base64,SGVsbG8="),
     /Expected a PNG data URL/
   );
+});
+
+test("playwright capture matrix helpers build quick and full validation scenarios", () => {
+  const quick = createCaptureScenarios({
+    geometry: "mesh",
+    matrixMode: "quick",
+    cameraPresets: ["reference"],
+    samplesPerPixelMatrix: [8],
+    denoiseMatrix: [true],
+  });
+  assert.equal(quick.length, 16);
+  assert.deepEqual(quick[0].cameraPreset, "reference");
+  assert.deepEqual(quick[0].samplesPerPixel, 8);
+  assert.deepEqual(quick[0].denoise, true);
+  assert.match(quick[0].reproCommand, /PLASIUS_CAPTURE_MATRIX_MODE=quick/);
+
+  const full = createCaptureScenarios({
+    geometry: "mesh",
+    matrixMode: "full",
+    cameraPresets: ["reference", "wide"],
+    samplesPerPixelMatrix: [1, 32],
+    denoiseMatrix: [true, false],
+  });
+  assert.equal(full.length, 16 * 2 * 2 * 2);
+  assert.ok(full.some((scenario) => scenario.cameraPreset === "wide"));
+  assert.ok(full.some((scenario) => scenario.samplesPerPixel === 32 && scenario.denoise === false));
 });
 
 test("playwright capture server helpers prefer reusable servers before free-port fallback", async () => {


### PR DESCRIPTION
## Summary
- script quick/full Eames validation matrices across camera, SPP, and denoise combinations
- persist richer per-scenario artifacts with capture URLs, repro commands, and texture/luminance metrics
- write manifest/summary failure diagnostics even when Chromium bootstrap fails before page load

## Tracking
- Parent story: Plasius-LTD/plasius-ltd-site#1097
- Tasks: Plasius-LTD/gpu-lighting#51, Plasius-LTD/gpu-lighting#52
- Follow-on scope for remaining non-Eames scenes: Plasius-LTD/gpu-lighting#55

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test:coverage`
- `npm run build`
- `PLASIUS_CAPTURE_PRESETS=warehouse-midday PLASIUS_CAPTURE_CAMERA_PRESETS=reference PLASIUS_CAPTURE_SPP_MATRIX=1 PLASIUS_CAPTURE_DENOISE_MATRIX=1 PLASIUS_CAPTURE_MATRIX_MODE=quick node scripts/eames-environments/capture.mjs` (expected environment bootstrap failure reproduced here; script now still writes `output/playwright/eames-environments/manifest.json` and `summary.md`)
