### PR TITLE
feat: surface renderer guardrails in validation hud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - The Eames validation harness now supports scripted quick/full screenshot
     matrices with configurable camera, SPP, and denoise combinations plus
     manifest-level failure diagnostics for reference runs.
+  - The Eames validation HUD/result now preserves renderer transport
+    guardrails, including jobs, submissions, memory, queue-overflow, and
+    device-loss diagnostics for release validation.
 
 - **Changed**
   - Wavefront ray-record documentation now mirrors the current renderer payload

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ signals. The manifest and summary now also retain failure diagnostics instead of
 stopping with only terminal output. The validation page now decouples optional
 probe readback from the heavy render submission itself, which keeps higher-SPP
 screenshot validation more stable.
+The validation HUD/result also surfaces renderer transport guardrails, so
+completed jobs, dispatch/submission counts, frame time, tracked memory,
+queue-overflow, device-loss state, and adapter capability hints travel with the
+same JSON evidence used for release validation.
 For motion or realtime validation, the page also accepts `frameTimeBudgetMs`
 and will render at least one full-screen sample before adaptively spending the
 rest of the per-frame budget on additional SPP passes. The HUD reports

--- a/demo/eames-environments/page.js
+++ b/demo/eames-environments/page.js
@@ -784,9 +784,135 @@ function summarizeCenterProbe(probeSummary) {
   };
 }
 
+function formatOptionalNumber(value, digits = 1) {
+  return Number.isFinite(value) ? Number(value).toFixed(digits) : null;
+}
+
+function formatOptionalInteger(value) {
+  return Number.isFinite(value) ? Number(value).toLocaleString() : null;
+}
+
+function formatMemoryBytes(totalBytes) {
+  if (!Number.isFinite(totalBytes)) {
+    return "memory unavailable";
+  }
+  if (totalBytes < 1024) {
+    return `${Math.round(totalBytes)} B`;
+  }
+  if (totalBytes < 1024 * 1024) {
+    return `${(totalBytes / 1024).toFixed(1)} KiB`;
+  }
+  return `${(totalBytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+function describeDeviceLossStatus(status) {
+  switch (status) {
+    case "lost":
+      return "device lost";
+    case "pending":
+      return "device status pending";
+    case "not-exposed":
+      return "device status unavailable";
+    case "not-detected":
+      return "device stable";
+    default:
+      return "device status unavailable";
+  }
+}
+
+function readRendererGuardrailCurrent(renderer = {}) {
+  const workerJobs = renderer.gpuWorkerJobs ?? {};
+  const guardrails = renderer.transportGuardrails?.current ?? {};
+  const memory = guardrails.memory ?? {};
+  return {
+    jobsPerFrame: Number.isFinite(guardrails.jobsPerFrame)
+      ? Number(guardrails.jobsPerFrame)
+      : Number.isFinite(workerJobs.completedPerFrame)
+        ? Number(workerJobs.completedPerFrame)
+        : null,
+    jobsPerSecond: Number.isFinite(guardrails.jobsPerSecond)
+      ? Number(guardrails.jobsPerSecond)
+      : Number.isFinite(workerJobs.completedPerSecond)
+        ? Number(workerJobs.completedPerSecond)
+        : null,
+    jobsPerSubmission: Number.isFinite(guardrails.jobsPerSubmission)
+      ? Number(guardrails.jobsPerSubmission)
+      : Number.isFinite(workerJobs.completedPerSubmission)
+        ? Number(workerJobs.completedPerSubmission)
+        : null,
+    commandSubmissions: Number.isFinite(guardrails.commandSubmissions)
+      ? Number(guardrails.commandSubmissions)
+      : Number.isFinite(renderer.commandSubmissions)
+        ? Number(renderer.commandSubmissions)
+        : null,
+    frameTimeMs: Number.isFinite(guardrails.frameTimeMs)
+      ? Number(guardrails.frameTimeMs)
+      : Number.isFinite(workerJobs.frameTimeMs)
+        ? Number(workerJobs.frameTimeMs)
+        : Number.isFinite(renderer.frameTimeMs)
+          ? Number(renderer.frameTimeMs)
+          : null,
+    queueOverflow: Number.isFinite(guardrails.queueOverflow)
+      ? Number(guardrails.queueOverflow)
+      : Number.isFinite(renderer.queueOverflow)
+        ? Number(renderer.queueOverflow)
+        : null,
+    deviceLossStatus: guardrails.deviceLossStatus ?? renderer.deviceLossStatus ?? null,
+    totalMemoryBytes: Number.isFinite(memory.totalBytes)
+      ? Number(memory.totalBytes)
+      : Number.isFinite(renderer.memory?.totalHotBufferBytes)
+        ? Number(renderer.memory.totalHotBufferBytes)
+        : null,
+  };
+}
+
+export function formatRendererTransportHudLines(renderer = {}) {
+  const workerJobs = renderer.gpuWorkerJobs ?? {};
+  const current = readRendererGuardrailCurrent(renderer);
+  const transportStatus = renderer.transportGuardrails?.status ?? "pending";
+  const directDispatches = formatOptionalInteger(workerJobs.directDispatchesCompleted);
+  const indirectDispatches = formatOptionalInteger(workerJobs.indirectDispatchesCompleted);
+  const jobsPerFrame = formatOptionalInteger(current.jobsPerFrame);
+  const jobsPerSecond = formatOptionalNumber(current.jobsPerSecond, 1);
+  const jobsPerSubmission = formatOptionalNumber(current.jobsPerSubmission, 2);
+  const commandSubmissions = formatOptionalInteger(current.commandSubmissions);
+  const frameTimeMs = formatOptionalNumber(current.frameTimeMs, 1);
+  const queueOverflow = formatOptionalInteger(current.queueOverflow);
+  const parallelism = renderer.gpuParallelism ?? {};
+  const directWorkgroups = formatOptionalInteger(
+    parallelism.largestDirectWorkgroupsPerDispatch
+  );
+  const indirectWorkgroups = formatOptionalInteger(
+    parallelism.largestEstimatedIndirectWorkgroupsPerDispatch
+  );
+
+  return [
+    [
+      jobsPerFrame ? `${jobsPerFrame} completed jobs` : "completed jobs pending",
+      directDispatches && indirectDispatches
+        ? `${directDispatches} direct + ${indirectDispatches} indirect dispatches`
+        : "dispatch counts unavailable",
+      commandSubmissions ? `${commandSubmissions} submissions` : "submissions pending",
+      jobsPerSubmission ? `${jobsPerSubmission} jobs/submission` : "jobs/submission pending",
+      jobsPerSecond ? `${jobsPerSecond} jobs/s` : "jobs/s pending GPU completion",
+    ].join(", "),
+    [
+      frameTimeMs ? `${frameTimeMs} ms frame time` : "frame time pending",
+      formatMemoryBytes(current.totalMemoryBytes),
+      queueOverflow ? `${queueOverflow} queue-overflow terminations` : "no queue-overflow terminations",
+      describeDeviceLossStatus(current.deviceLossStatus),
+      `guardrails ${transportStatus}`,
+    ].join(", "),
+    typeof parallelism.exposesMultiWorkgroupParallelism === "boolean"
+      ? parallelism.exposesMultiWorkgroupParallelism
+        ? `capability: multi-workgroup GPU dispatch${directWorkgroups ? `, direct <= ${directWorkgroups} wg` : ""}${indirectWorkgroups ? `, indirect <= ${indirectWorkgroups} wg` : ""}`
+        : "capability: single-workgroup GPU dispatch"
+      : "capability summary unavailable",
+  ];
+}
+
 function updateHud(hud, result) {
   const sourceLabels = result.lightSources.map((source) => `${source.kind}/${source.role}`).join(", ");
-  const workerJobs = result.renderer.gpuWorkerJobs;
   const renderedSamplesPerPixel = Number(
     result.renderer.renderedSamplesPerPixel ?? result.samplesPerPixel
   );
@@ -803,10 +929,6 @@ function updateHud(hud, result) {
         : targetSamplesPerPixel === requestedSamplesPerPixel
           ? `${renderedSamplesPerPixel}/${requestedSamplesPerPixel} spp`
           : `${renderedSamplesPerPixel}/${targetSamplesPerPixel}/${requestedSamplesPerPixel} spp`;
-  const jobsPerSecond =
-    typeof workerJobs.completedPerSecond === "number"
-      ? `${workerJobs.completedPerSecond.toFixed(1)} jobs/s`
-      : "jobs/s pending GPU completion";
   const budgetLabel =
     Number.isFinite(result.renderer.frameTimeBudgetMs) && result.renderer.frameTimeBudgetMs > 0
       ? `, ${result.renderer.frameTimeBudgetMs} ms budget${result.renderer.budgetConstrained ? ", adaptive" : ""}`
@@ -815,6 +937,7 @@ function updateHud(hud, result) {
   const governorLabel = governor?.enabled
     ? `${governor.currentLevelId}, ${governor.pressureLevel} pressure`
     : "governor off";
+  const [jobsLine, guardrailLine, capabilityLine] = formatRendererTransportHudLines(result.renderer);
   hud.innerHTML = `
     <strong>${result.preset}</strong>
     <span>${result.scene} - ${result.timeOfDay} - ${result.geometry}</span>
@@ -822,8 +945,9 @@ function updateHud(hud, result) {
     <span>${result.width}x${result.height}, ${sppLabel}${budgetLabel}, denoise ${result.denoise ? "on" : "off"}, deferred ${result.deferredPathResolve ? "on" : "off"}</span>
     <span>${result.triangleCount.toLocaleString()} triangles, ${result.sceneObjectCount} analytic surfaces</span>
     <span>${governorLabel}</span>
-    <span>${workerJobs.completedPerFrame.toLocaleString()} GPU jobs/frame, ${jobsPerSecond}, ${workerJobs.completedPerSubmission.toFixed(2)} jobs/submission</span>
-    <span>${result.renderer.gpuParallelism.exposesMultiWorkgroupParallelism ? "multi-workgroup GPU dispatch" : "single-workgroup GPU dispatch"}</span>
+    <span>${jobsLine}</span>
+    <span>${guardrailLine}</span>
+    <span>${capabilityLine}</span>
   `;
 }
 
@@ -1017,9 +1141,14 @@ export async function renderEamesEnvironment(options = {}) {
       budgetConstrained: stats.budgetConstrained,
       adaptiveSampling: adaptiveSamplingSnapshot,
       cameraPreset,
+      commandSubmissions: stats.commandSubmissions,
+      deviceLossStatus: stats.deviceLossStatus ?? null,
       gpuWorkerJobs: stats.gpuWorkerJobs,
       gpuParallelism: stats.gpuParallelism,
+      memory: stats.memory ?? null,
       outputProbe,
+      queueOverflow: stats.queueOverflow ?? 0,
+      transportGuardrails: stats.transportGuardrails ?? null,
     },
     probeSummary,
   };

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -55,6 +55,7 @@ const {
   createAdaptiveSamplingController,
   createEnvironmentCamera,
   createCaptureState,
+  formatRendererTransportHudLines,
   listCaptureUploadUrlCandidates,
   MODEL_URL,
   normalizeCaptureError,
@@ -1512,8 +1513,29 @@ test("validation render decouples frame rendering from optional probe readback",
           frameTimeMs: 100,
           awaitedGpuCompletion: true,
         },
+        commandSubmissions: 3,
+        deviceLossStatus: "not-detected",
         gpuParallelism: { exposesMultiWorkgroupParallelism: true },
+        memory: {
+          totalHotBufferBytes: 32768,
+        },
         outputProbe: null,
+        queueOverflow: 0,
+        transportGuardrails: {
+          status: "pass",
+          current: {
+            jobsPerFrame: 42,
+            jobsPerSecond: 420,
+            jobsPerSubmission: 14,
+            commandSubmissions: 3,
+            frameTimeMs: 100,
+            queueOverflow: 0,
+            deviceLossStatus: "not-detected",
+            memory: {
+              totalBytes: 32768,
+            },
+          },
+        },
       };
     },
     async readOutputProbe({ x, y }) {
@@ -1599,7 +1621,67 @@ test("validation render decouples frame rendering from optional probe readback",
   assert.equal(result.renderer.gpuWorkerJobs.completedPerFrame, 42);
   assert.equal(result.renderer.gpuWorkerJobs.completedPerSecond, 420);
   assert.equal(result.renderer.gpuWorkerJobs.completedPerSubmission, 14);
+  assert.equal(result.renderer.commandSubmissions, 3);
+  assert.equal(result.renderer.deviceLossStatus, "not-detected");
+  assert.equal(result.renderer.transportGuardrails.status, "pass");
+  assert.equal(result.renderer.transportGuardrails.current.memory.totalBytes, 32768);
   assert.equal(result.probeSummary.sampledPixels, 5);
+});
+
+test("renderer transport hud lines surface guardrails and degrade gracefully when metrics are missing", () => {
+  const populated = formatRendererTransportHudLines({
+    commandSubmissions: 3,
+    deviceLossStatus: "not-detected",
+    gpuWorkerJobs: {
+      completedPerFrame: 42,
+      completedPerSecond: 420,
+      completedPerSubmission: 14,
+      directDispatchesCompleted: 18,
+      indirectDispatchesCompleted: 24,
+      frameTimeMs: 100,
+    },
+    gpuParallelism: {
+      exposesMultiWorkgroupParallelism: true,
+      largestDirectWorkgroupsPerDispatch: 4096,
+      largestEstimatedIndirectWorkgroupsPerDispatch: 256,
+    },
+    memory: {
+      totalHotBufferBytes: 32768,
+    },
+    queueOverflow: 0,
+    transportGuardrails: {
+      status: "pass",
+      current: {
+        jobsPerFrame: 42,
+        jobsPerSecond: 420,
+        jobsPerSubmission: 14,
+        commandSubmissions: 3,
+        frameTimeMs: 100,
+        queueOverflow: 0,
+        deviceLossStatus: "not-detected",
+        memory: {
+          totalBytes: 32768,
+        },
+      },
+    },
+  });
+  const missing = formatRendererTransportHudLines({
+    gpuWorkerJobs: {},
+    gpuParallelism: {},
+  });
+
+  assert.match(populated[0], /42 completed jobs/);
+  assert.match(populated[0], /18 direct \+ 24 indirect dispatches/);
+  assert.match(populated[1], /32\.0 KiB/);
+  assert.match(populated[1], /guardrails pass/);
+  assert.match(populated[2], /multi-workgroup GPU dispatch/);
+  assert.match(populated[2], /direct <= 4,096 wg/);
+
+  assert.match(missing[0], /completed jobs pending/);
+  assert.match(missing[0], /jobs\/s pending GPU completion/);
+  assert.match(missing[1], /memory unavailable/);
+  assert.match(missing[1], /guardrails pending/);
+  assert.match(missing[2], /capability summary unavailable/);
 });
 
 test("validation render can rebuild animated source markers with injected runtime helpers", async () => {


### PR DESCRIPTION
## Summary
- surface renderer transport guardrail metrics in the Eames validation HUD and JSON result
- preserve graceful fallback strings when throughput, memory, or capability metrics are unavailable
- document the new validation evidence in the package README and changelog

## Validation
- `npm run test:coverage`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run pack:check`
- `npm run audit:npm`

## Links
- Plasius-LTD/plasius-ltd-site#1098
- Plasius-LTD/gpu-lighting#53
