### PR TITLE
[codex] Refresh gpu-lighting dependency baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - (placeholder)
 
 - **Changed**
-  - (placeholder)
+  - Refreshed direct runtime and validation dependencies to the latest stable
+    published baselines, including the `@plasius/gpu-shared` 1.x line and the
+    current `@plasius/gpu-worker`, `@plasius/gpu-renderer`, Playwright, ESLint,
+    and `globals` releases.
 
 - **Fixed**
-  - (placeholder)
+  - Regenerated `package-lock.json` from a clean Node 24 install so the lockfile
+    matches the published dependency ranges declared in `package.json`.
 
 - **Security**
   - (placeholder)

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,16 +19,16 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@plasius/gpu-shared": "^0.1.9",
-        "@plasius/gpu-worker": "^0.1.15"
+        "@plasius/gpu-shared": "^1.0.1",
+        "@plasius/gpu-worker": "^0.3.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@plasius/gpu-renderer": "^0.2.7",
-        "@playwright/test": "^1.60.0",
+        "@plasius/gpu-renderer": "^0.2.19",
+        "@playwright/test": "^1.61.1",
         "c8": "^11.0.0",
-        "eslint": "^10.3.0",
-        "globals": "^17.6.0",
+        "eslint": "^10.6.0",
+        "globals": "^17.7.0",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3"
       },
@@ -732,9 +732,9 @@
       }
     },
     "node_modules/@plasius/gpu-lock-free-queue": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@plasius/gpu-lock-free-queue/-/gpu-lock-free-queue-0.2.19.tgz",
-      "integrity": "sha512-poq9obAlDJfBtbdj9ogWI1JKmDb3FXdExfgXwKmMO1EDhXSYUwcIamELUc0ep2wXo/5VAle9u3b+Or5v8zeq5A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-lock-free-queue/-/gpu-lock-free-queue-0.3.2.tgz",
+      "integrity": "sha512-l+1jb31Fm/nelfWXN0qRsJICZeOfoWABEb4DDuJ2Pp4kYglio2h7vnWJ75l5FxD48ME8WU5DRGY6f5Gbayj6gg==",
       "funding": [
         {
           "type": "patreon",
@@ -753,31 +753,7 @@
         "node": ">=24"
       }
     },
-    "node_modules/@plasius/gpu-renderer": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@plasius/gpu-renderer/-/gpu-renderer-0.2.17.tgz",
-      "integrity": "sha512-Hefk/iu6MHi9LUIaTOIWNeCHu2bVNbHSLdiheaVE72f/0kqDB0BpD6RAR2jJJGQ6p5mqMcuXKEP1FclN+wmgKw==",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/c/plasiusltd/membership"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/Plasius-LTD"
-        }
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@plasius/gpu-shared": "^0.1.11",
-        "@plasius/gpu-xr": "^0.1.11"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/@plasius/gpu-shared": {
+    "node_modules/@plasius/gpu-lock-free-queue/node_modules/@plasius/gpu-shared": {
       "version": "0.1.20",
       "resolved": "https://registry.npmjs.org/@plasius/gpu-shared/-/gpu-shared-0.1.20.tgz",
       "integrity": "sha512-YsZo1Id+UnVxr1YshrfI/N0DuVfkq7De+W9RZA5daM0STwgelh71G6Kk24Pv893g76nrBuyH0SyTgmhjMvAvTA==",
@@ -808,10 +784,11 @@
         }
       }
     },
-    "node_modules/@plasius/gpu-worker": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@plasius/gpu-worker/-/gpu-worker-0.1.17.tgz",
-      "integrity": "sha512-Y1D4BnZboApLwnJovp0+wk9fYH+Nj5Mzv3nTaA5juSHtrSUm92SRwNBwVVERwm6JW+fi/HV6AmjarrfEsV+ObA==",
+    "node_modules/@plasius/gpu-renderer": {
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-renderer/-/gpu-renderer-0.2.19.tgz",
+      "integrity": "sha512-0wonw7K0tX+YSQlXMRNDaMpxHtG4C9on5flU1at3iAdIR1DXJpJm6DPcp4+ZMIx7ZJ1Fne/hH1MZvEToLGZrlg==",
+      "devOptional": true,
       "funding": [
         {
           "type": "patreon",
@@ -824,8 +801,94 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@plasius/gpu-lock-free-queue": "^0.2.18",
-        "@plasius/gpu-shared": "^0.1.9"
+        "@plasius/gpu-shared": "^0.1.11",
+        "@plasius/gpu-xr": "^0.1.11"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@plasius/gpu-renderer/node_modules/@plasius/gpu-shared": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-shared/-/gpu-shared-0.1.20.tgz",
+      "integrity": "sha512-YsZo1Id+UnVxr1YshrfI/N0DuVfkq7De+W9RZA5daM0STwgelh71G6Kk24Pv893g76nrBuyH0SyTgmhjMvAvTA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/c/plasiusltd/membership"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Plasius-LTD"
+        }
+      ],
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "@plasius/gpu-renderer": "^0.2.3",
+        "@plasius/translations": "^1.0.17"
+      },
+      "peerDependenciesMeta": {
+        "@plasius/gpu-renderer": {
+          "optional": true
+        },
+        "@plasius/translations": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@plasius/gpu-shared": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-shared/-/gpu-shared-1.0.1.tgz",
+      "integrity": "sha512-2+j6Gph/PuGmzTJJI/ZR8qGYfaEjLcN0+8zk/UEctVJyIb9+GMhE1Trkxg7L76qnaeO7g7LHAULwOuTTz5aOZQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/c/plasiusltd/membership"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Plasius-LTD"
+        }
+      ],
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "@plasius/gpu-renderer": "^0.2.3",
+        "@plasius/translations": "^1.0.17"
+      },
+      "peerDependenciesMeta": {
+        "@plasius/gpu-renderer": {
+          "optional": true
+        },
+        "@plasius/translations": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@plasius/gpu-worker": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-worker/-/gpu-worker-0.3.3.tgz",
+      "integrity": "sha512-U5Eb7G7uGk1KLLsTI3JnTxzHcD+KC9fZKKk2W+LvfVMTCWyC/HDOdQOwDow0YldDaeo1LgQJOZliu1KHSYmAIQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/c/plasiusltd/membership"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Plasius-LTD"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@plasius/gpu-lock-free-queue": "^0.3.2",
+        "@plasius/gpu-shared": "^1.0.1"
       },
       "engines": {
         "node": ">=24"
@@ -854,14 +917,46 @@
         "node": ">=24"
       }
     },
+    "node_modules/@plasius/gpu-xr/node_modules/@plasius/gpu-shared": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-shared/-/gpu-shared-0.1.20.tgz",
+      "integrity": "sha512-YsZo1Id+UnVxr1YshrfI/N0DuVfkq7De+W9RZA5daM0STwgelh71G6Kk24Pv893g76nrBuyH0SyTgmhjMvAvTA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/c/plasiusltd/membership"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Plasius-LTD"
+        }
+      ],
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "@plasius/gpu-renderer": "^0.2.3",
+        "@plasius/translations": "^1.0.17"
+      },
+      "peerDependenciesMeta": {
+        "@plasius/gpu-renderer": {
+          "optional": true
+        },
+        "@plasius/translations": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@playwright/test": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
-      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1332,9 +1427,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1602,9 +1697,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2409,13 +2504,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2428,9 +2523,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -55,11 +55,11 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@plasius/gpu-renderer": "^0.2.7",
-    "@playwright/test": "^1.60.0",
+    "@plasius/gpu-renderer": "^0.2.19",
+    "@playwright/test": "^1.61.1",
     "c8": "^11.0.0",
-    "eslint": "^10.3.0",
-    "globals": "^17.6.0",
+    "eslint": "^10.6.0",
+    "globals": "^17.7.0",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3"
   },
@@ -85,8 +85,8 @@
     }
   ],
   "dependencies": {
-    "@plasius/gpu-shared": "^0.1.9",
-    "@plasius/gpu-worker": "^0.1.15"
+    "@plasius/gpu-shared": "^1.0.1",
+    "@plasius/gpu-worker": "^0.3.3"
   },
   "overrides": {
     "minimatch": "^10.2.1"

--- a/tests/demo-contract.test.js
+++ b/tests/demo-contract.test.js
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import * as lightingPackage from "../dist/index.js";
+import { createLightingDemoMountOptions } from "../demo/lighting-demo-config.js";
 
 const repoRoot = fileURLToPath(new URL("../", import.meta.url));
 
@@ -41,4 +43,18 @@ test("lighting demo browser entry uses the public gpu-shared package surface", (
   assert.doesNotMatch(source, /node_modules\/@plasius\/gpu-shared\/dist/);
   assert.doesNotMatch(readme, /does not mount a 3D canvas/i);
   assert.match(readme, /mounts the shared 3D harbor validation scene/i);
+});
+
+test("lighting demo runtime resolves the injected lighting package loader", async () => {
+  const mountOptions = createLightingDemoMountOptions({ id: "demo-root" });
+
+  assert.equal(typeof mountOptions.__showcaseFeatureLoaders?.lighting, "function");
+
+  const loadedLightingPackage = await mountOptions.__showcaseFeatureLoaders.lighting();
+
+  assert.equal(
+    loadedLightingPackage.createLightingBandPlan,
+    lightingPackage.createLightingBandPlan
+  );
+  assert.equal(loadedLightingPackage.defaultLightingProfile, lightingPackage.defaultLightingProfile);
 });


### PR DESCRIPTION
## What changed
- refreshed direct runtime and validation dependencies to the latest published stable baselines
- regenerated `package-lock.json` from a clean Node 24 install
- added a runtime regression test that resolves the injected `__showcaseFeatureLoaders.lighting()` loader instead of only checking the wiring textually

## Why
- issue #15 requires a clean dependency refresh with explicit validation evidence
- reviewer feedback on #15 asked for direct proof that the shared showcase loader path is consumed once `@plasius/gpu-shared` is updated

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:coverage`
- `npm run audit:npm`
- `npm run audit:deps`
- `npm run pack:check`

Fixes #15
